### PR TITLE
refactor lemming to take a net listener this makes testing easiler since

### DIFF
--- a/gnmi/gnmi.go
+++ b/gnmi/gnmi.go
@@ -68,15 +68,16 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 func (s *Server) Subscribe(stream gnmipb.GNMI_SubscribeServer) error {
 	_, err := stream.Recv()
 	if err != nil {
-		return grpc.Errorf(codes.Internal, "Subscribe Recv failed: %v", err)
+		return err
 	}
 	srs := s.Responses[s.subscription]
+	if len(s.Errs) != s.subscription+1 {
+		s.Errs = append(s.Errs, nil)
+	}
 	srErr := s.Errs[s.subscription]
 	s.subscription++
 	for _, sr := range srs {
-		if err := stream.Send(sr); err != nil {
-			return grpc.Errorf(codes.Internal, "Subscribe Send failed: %v", err)
-		}
+		stream.Send(sr)
 	}
 	time.Sleep(5 * time.Second)
 	return srErr

--- a/lemming_test.go
+++ b/lemming_test.go
@@ -16,6 +16,7 @@ package lemming
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -47,7 +48,11 @@ import (
 )
 
 func TestFakeGNMI(t *testing.T) {
-	f, err := New("localhost:0")
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to start listener: %v", err)
+	}
+	f, err := New(lis)
 	if err != nil {
 		t.Fatalf("failed to start fake: %v", err)
 	}
@@ -86,10 +91,11 @@ func TestFakeGNMI(t *testing.T) {
 }
 
 func TestFakeGNOI(t *testing.T) {
-	f, err := New("localhost:0")
+	lis, err := net.Listen("tcp", ":0")
 	if err != nil {
-		t.Fatalf("failed to start fake: %v", err)
+		t.Fatalf("failed to start listener: %v", err)
 	}
+	f, err := New(lis)
 	defer f.stop()
 	conn, err := grpc.Dial(f.addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -190,7 +196,11 @@ func TestFakeGNOI(t *testing.T) {
 func TestGNSI(t *testing.T) {
 	desc := "gnsi.Authz.Rotate"
 	t.Run(desc, func(t *testing.T) {
-		f, err := New()
+		lis, err := net.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatalf("failed to start listener: %v", err)
+		}
+		f, err := New(lis)
 		if err != nil {
 			t.Fatalf("failed to start fake: %v", err)
 		}
@@ -212,7 +222,11 @@ func TestGNSI(t *testing.T) {
 
 	desc = "gnsi.Cert.Install"
 	t.Run(desc, func(t *testing.T) {
-		f, err := New()
+		lis, err := net.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatalf("failed to start listener: %v", err)
+		}
+		f, err := New(lis)
 		if err != nil {
 			t.Fatalf("failed to start fake: %v", err)
 		}
@@ -234,7 +248,11 @@ func TestGNSI(t *testing.T) {
 
 	desc = "gnsi.Console.MutateAccountPassword"
 	t.Run(desc, func(t *testing.T) {
-		f, err := New()
+		lis, err := net.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatalf("failed to start listener: %v", err)
+		}
+		f, err := New(lis)
 		if err != nil {
 			t.Fatalf("failed to start fake: %v", err)
 		}
@@ -256,7 +274,11 @@ func TestGNSI(t *testing.T) {
 
 	desc = "gnsi.Pathz.Install"
 	t.Run(desc, func(t *testing.T) {
-		f, err := New()
+		lis, err := net.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatalf("failed to start listener: %v", err)
+		}
+		f, err := New(lis)
 		if err != nil {
 			t.Fatalf("failed to start fake: %v", err)
 		}
@@ -278,7 +300,11 @@ func TestGNSI(t *testing.T) {
 
 	desc = "gnsi.SSH.MutateAccountCredentials"
 	t.Run(desc, func(t *testing.T) {
-		f, err := New()
+		lis, err := net.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatalf("failed to start listener: %v", err)
+		}
+		f, err := New(lis)
 		if err != nil {
 			t.Fatalf("failed to start fake: %v", err)
 		}


### PR DESCRIPTION
ports can be allocated before trying to use the device