### PR TITLE
Allow the datastore to update state values by calling GnmiUpdate directly.

### DIFF
--- a/gnmi/gnmit/datastore.go
+++ b/gnmi/gnmit/datastore.go
@@ -27,6 +27,10 @@ func NewDatastoreServer(gnmiServer *GNMIServer) *DatastoreServer {
 }
 
 func (d *DatastoreServer) Set(_ context.Context, req *gpb.SetRequest) (*gpb.SetResponse, error) {
+	// TODO(wenbli): Reject values that modify config values. We only allow modifying state through this server.
+	// TODO(wenbli): Unmarshal to a struct without PreferShadowPath in
+	// order to validate that state paths are valid according to the
+	// schema.
 	if err := d.gnmiServer.set(req, false); err != nil {
 		return &gpb.SetResponse{}, status.Errorf(codes.Aborted, "%v", err)
 	}

--- a/gnmi/gnmit/gnmit.go
+++ b/gnmi/gnmit/gnmit.go
@@ -457,7 +457,6 @@ func (s *GNMIServer) update(dirtyRoot ygot.ValidatedGoStruct, origin string) err
 	if err := t.GnmiUpdate(n); err != nil {
 		return err
 	}
-	s.c.Schema().Root = dirtyRoot
 	return nil
 }
 
@@ -466,7 +465,7 @@ func (s *GNMIServer) update(dirtyRoot ygot.ValidatedGoStruct, origin string) err
 //
 // update indicates whether to update the cache with the values from the set
 // request.
-func (s *GNMIServer) set(req *gpb.SetRequest, update bool) error {
+func (s *GNMIServer) set(req *gpb.SetRequest, updateCache bool) error {
 	s.intendedConfigMu.Lock()
 	defer s.intendedConfigMu.Unlock()
 	dirtyRoot, node, nodeName, err := s.getOrCreateNode(req.Prefix)
@@ -498,7 +497,9 @@ func (s *GNMIServer) set(req *gpb.SetRequest, update bool) error {
 		return fmt.Errorf("gnmit: invalid SetRequest: %v", err)
 	}
 
-	if update {
+	s.c.Schema().Root = dirtyRoot
+
+	if updateCache {
 		return s.update(dirtyRoot, req.Prefix.Origin)
 	}
 	return nil

--- a/gnmi/gnmit/gnmit.go
+++ b/gnmi/gnmit/gnmit.go
@@ -497,11 +497,12 @@ func (s *GNMIServer) set(req *gpb.SetRequest, updateCache bool) error {
 		return fmt.Errorf("gnmit: invalid SetRequest: %v", err)
 	}
 
-	s.c.Schema().Root = dirtyRoot
-
 	if updateCache {
-		return s.update(dirtyRoot, req.Prefix.Origin)
+		if err := s.update(dirtyRoot, req.Prefix.Origin); err != nil {
+			return err
+		}
 	}
+	s.c.Schema().Root = dirtyRoot
 	return nil
 }
 

--- a/gnmi/gnmit/gnmit.go
+++ b/gnmi/gnmit/gnmit.go
@@ -433,10 +433,6 @@ func (s *GNMIServer) getOrCreateNode(path *gpb.Path) (ygot.ValidatedGoStruct, yg
 }
 
 func (s *GNMIServer) update(dirtyRoot ygot.ValidatedGoStruct, origin string) error {
-	if err := dirtyRoot.Validate(); err != nil {
-		return fmt.Errorf("gnmit: invalid SetRequest: %v", err)
-	}
-
 	n, err := ygot.Diff(s.c.Schema().Root, dirtyRoot, &ygot.DiffPathOpt{PreferShadowPath: true})
 	if err != nil {
 		return fmt.Errorf("gnmit: error while creating update notification for Set: %v", err)
@@ -467,7 +463,10 @@ func (s *GNMIServer) update(dirtyRoot ygot.ValidatedGoStruct, origin string) err
 
 // set updates the datastore and intended configuration with the SetRequest,
 // allowing read-only values to be updated.
-func (s *GNMIServer) set(req *gpb.SetRequest) error {
+//
+// update indicates whether to update the cache with the values from the set
+// request.
+func (s *GNMIServer) set(req *gpb.SetRequest, update bool) error {
 	s.intendedConfigMu.Lock()
 	defer s.intendedConfigMu.Unlock()
 	dirtyRoot, node, nodeName, err := s.getOrCreateNode(req.Prefix)
@@ -495,7 +494,14 @@ func (s *GNMIServer) set(req *gpb.SetRequest) error {
 		}
 	}
 
-	return s.update(dirtyRoot, req.Prefix.Origin)
+	if err := dirtyRoot.Validate(); err != nil {
+		return fmt.Errorf("gnmit: invalid SetRequest: %v", err)
+	}
+
+	if update {
+		return s.update(dirtyRoot, req.Prefix.Origin)
+	}
+	return nil
 }
 
 // Set is a prototype for a gNMI Set operation.
@@ -506,7 +512,7 @@ func (s *GNMIServer) Set(ctx context.Context, req *gpb.SetRequest) (*gpb.SetResp
 
 	// TODO(wenbli): Reject paths that try to modify read-only values.
 	// TODO(wenbli): Question: what to do if there are operational-state values in a container that is specified to be replaced or deleted?
-	err := s.set(req)
+	err := s.set(req, true)
 
 	// TODO(wenbli): Currently the SetResponse is not filled.
 	return &gpb.SetResponse{

--- a/gnmi/testagent/testagent.go
+++ b/gnmi/testagent/testagent.go
@@ -53,7 +53,7 @@ func main() {
 	go func() {
 		for count := 0; ; count++ {
 			time.Sleep(1 * time.Second)
-			p, _, err := ygnmi.ResolvePath(ocpath.Root().Interface("test-eth0").Description().Config().PathStruct())
+			p, _, err := ygnmi.ResolvePath(ocpath.Root().Interface("test-eth0").Description().State().PathStruct())
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
Also fix testagentlocal which was continuously updating the applied state even when there were no updates. Alas, easy to get things wrong without a test.