### PR TITLE
Convert ygnmi GoBGP task

### DIFF
--- a/gnmi/fakedevice/fakedevice.go
+++ b/gnmi/fakedevice/fakedevice.go
@@ -32,6 +32,10 @@ import (
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
+const (
+	DefaultNetworkInstance = "DEFAULT"
+)
+
 var PathTranslator *pathtranslate.PathTranslator
 
 func init() {
@@ -166,27 +170,6 @@ func StartSystemBaseTask(ctx context.Context, port int, target string, enableTLS
 	return nil
 }
 
-// Tasks returns the set of functions that should be called that may read
-// and/or modify internal state.
-//
-// These tasks are invoked during the creation of each device's Subscribe
-// server and may spawn long-running or future-running thread(s) that make
-// modifications to a device's cache.
-func Tasks(target string) []gnmit.Task {
-	// TODO(wenbli): We should decentralize how we add tasks by adding a
-	// register function that's called by various init() functions.
-	return []gnmit.Task{{
-		Run: goBgpTask,
-		Paths: []ygnmi.PathStruct{
-			ocpath.Root().NetworkInstance("default").Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp(),
-		},
-		Prefix: &gpb.Path{
-			Origin: "openconfig",
-			Target: target,
-		},
-	}}
-}
-
 // NewTarget creates a new gNMI fake device object.
 // This fake gNMI server simply mirrors whatever is set for its config leafs in
 // its state leafs. It also has a mechanism for adding new "tasks", or go
@@ -197,7 +180,7 @@ func NewTarget(ctx context.Context, addr, targetName string) (*gnmit.Collector, 
 	if err != nil {
 		return nil, "", fmt.Errorf("cannot create ygot schema object for gNMI target: %v", err)
 	}
-	c, addr, err := gnmit.NewSettable(ctx, addr, targetName, false, configSchema, Tasks(targetName))
+	c, addr, err := gnmit.NewSettable(ctx, addr, targetName, false, configSchema, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("cannot start server, got err: %v", err)
 	}

--- a/gnmi/fakedevice/fakedevice.go
+++ b/gnmi/fakedevice/fakedevice.go
@@ -26,10 +26,7 @@ import (
 	"github.com/openconfig/lemming/gnmi/oc"
 	"github.com/openconfig/lemming/gnmi/oc/ocpath"
 	"github.com/openconfig/ygnmi/ygnmi"
-	"github.com/openconfig/ygot/util"
 	"github.com/openconfig/ygot/ygot/pathtranslate"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
 const (
@@ -87,12 +84,6 @@ func StartCurrentDateTimeTask(ctx context.Context, port int, target string, enab
 	}()
 
 	return nil
-}
-
-// matchingPath returns true iff the path matches the given matcher path in
-// length and in values; wildcards are allowed in the matcher path.
-func matchingPath(path, matcher *gpb.Path) bool {
-	return len(path.Elem) == len(matcher.Elem) && util.PathMatchesQuery(path, matcher)
 }
 
 // StartSystemBaseTask handles some of the logic for the base systems feature

--- a/gnmi/fakedevice/gobgp.go
+++ b/gnmi/fakedevice/gobgp.go
@@ -5,27 +5,22 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
-	"time"
 
 	log "github.com/golang/glog"
-	"github.com/openconfig/gnmi/coalesce"
-	"github.com/openconfig/gnmi/ctree"
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
-	"github.com/openconfig/lemming/gnmi/gnmit"
+	"github.com/openconfig/lemming/gnmi/gnmiclient"
 	"github.com/openconfig/lemming/gnmi/oc"
 	"github.com/openconfig/lemming/gnmi/oc/ocpath"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 	api "github.com/osrg/gobgp/v3/api"
 	"github.com/osrg/gobgp/v3/pkg/server"
-	"google.golang.org/protobuf/encoding/prototext"
 )
 
 const (
 	listenPort = 1234
 )
 
-// goBgpTask tries to establish a simple BGP session using GoBGP. It returns an error if initialization failed.
+// StartGoBGPTask tries to establish a simple BGP session using GoBGP. It returns an error if initialization failed.
 //
 // TODO(wenbli): Break this function up.
 //
@@ -57,12 +52,20 @@ const (
 //     When there is a dependency, the later actions will NOT directly depend on the results of the previous actions, but will just look at the current config view to determine the appropriate action.
 //     e.g. for peers, if the global setting has been set up, then we can create the peers and update the applied config if it succeeds, but if not then we don't do anything.
 //     ; however, if the global setting hasn't been set up, we actually need to erase the entirety of the applied config. This is because the watcher doesn't tell us this information.
-func goBgpTask(getIntendedConfig func() *oc.Root, q gnmit.Queue, update gnmit.UpdateFn, target string, remove func()) error {
-	bgpPath := ocpath.Root().NetworkInstance("default").Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
-	bgpPathStr, _, err := ygnmi.ResolvePath(bgpPath)
+func StartGoBGPTask(ctx context.Context, port int, target string, enableTLS bool) error {
+	yclient, err := gnmiclient.NewYGNMIClient(port, target, enableTLS)
 	if err != nil {
-		return fmt.Errorf("goBgpTask failed to initialize due to error: %v", err)
+		return err
 	}
+
+	b := &ocpath.Batch{}
+	bgpPath := ocpath.Root().NetworkInstance(DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	b.AddPaths(
+		bgpPath.Global().As().Config().PathStruct(),
+		bgpPath.Global().RouterId().Config().PathStruct(),
+		bgpPath.NeighborAny().PeerAs().Config().PathStruct(),
+		bgpPath.NeighborAny().NeighborAddress().Config().PathStruct(),
+	)
 
 	s := server.NewBgpServer()
 	go s.Serve()
@@ -71,7 +74,7 @@ func goBgpTask(getIntendedConfig func() *oc.Root, q gnmit.Queue, update gnmit.Up
 
 	appliedRoot := &oc.Root{}
 	// appliedBgp is the SoT for BGP applied configuration. It is maintained locally by the task.
-	appliedBgp := appliedRoot.GetOrCreateNetworkInstance("default").GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
+	appliedBgp := appliedRoot.GetOrCreateNetworkInstance(DefaultNetworkInstance).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
 	appliedBgp.PopulateDefaults()
 	var appliedBgpMu sync.Mutex
 
@@ -89,11 +92,8 @@ func goBgpTask(getIntendedConfig func() *oc.Root, q gnmit.Queue, update gnmit.Up
 			return false
 		}
 		if len(no.GetUpdate())+len(no.GetDelete()) > 0 {
-			log.V(1).Info("Updating BGP applied configuration: ", prototext.Format(no))
-			no.Timestamp = time.Now().UnixNano()
-			no.Prefix = &gpb.Path{Origin: "openconfig", Target: target, Elem: bgpPathStr.Elem}
-
-			if err := update(no); err != nil {
+			_, err := gnmiclient.Update(ctx, yclient, bgpPath.State(), appliedBgp)
+			if err != nil {
 				log.Errorf("goBgpTask: error while writing update to applied configuration: %v", err)
 				return false
 			}
@@ -145,95 +145,22 @@ func goBgpTask(getIntendedConfig func() *oc.Root, q gnmit.Queue, update gnmit.Up
 		return fmt.Errorf("goBgpTask failed to initialize due to error: %v", err)
 	}
 
-	asPaths, _, err := ygnmi.ResolvePath(bgpPath.Global().As().Config().PathStruct())
-	if err != nil {
-		return fmt.Errorf("goBgpTask failed to initialize due to error: %v", err)
-	}
-	routeIDPaths, _, err := ygnmi.ResolvePath(bgpPath.Global().RouterId().Config().PathStruct())
-	if err != nil {
-		return fmt.Errorf("goBgpTask failed to initialize due to error: %v", err)
-	}
-	peerAsPaths, _, err := ygnmi.ResolvePath(bgpPath.NeighborAny().PeerAs().Config().PathStruct())
-	if err != nil {
-		return fmt.Errorf("goBgpTask failed to initialize due to error: %v", err)
-	}
-	neighAddrPaths, _, err := ygnmi.ResolvePath(bgpPath.NeighborAny().NeighborAddress().Config().PathStruct())
-	if err != nil {
-		return fmt.Errorf("goBgpTask failed to initialize due to error: %v", err)
-	}
-
 	var global api.Global
 	global.ListenPort = listenPort
 
-	go func() {
-		defer remove()
-		for {
-			item, _, err := q.Next(context.Background())
-			if coalesce.IsClosedQueue(err) {
-				return
+	bgpWatcher := ygnmi.Watch(
+		context.Background(),
+		yclient,
+		b.Config(),
+		func(root *ygnmi.Value[*oc.Root]) error {
+			rootVal, ok := root.Val()
+			if !ok {
+				return ygnmi.Continue
 			}
-			n, ok := item.(*ctree.Leaf)
-			if !ok || n == nil {
-				log.Errorf("goBgpTask invalid cache node: %#v", item)
-				return
-			}
-			v := n.Value()
-			no, ok := v.(*gpb.Notification)
-			if !ok || no == nil {
-				log.Errorf("goBgpTask invalid cache node, expected non-nil *gpb.Notification type, got: %#v", v)
-				return
-			}
-
-			// Update the view of the intended config.
-			// Note: We're guaranteed that whatever update came from the collector is valid since we validate before storing.
-			shouldProcess := false
-			for _, u := range no.Update {
-				switch {
-				case matchingPath(u.Path, asPaths), matchingPath(u.Path, routeIDPaths), matchingPath(u.Path, neighAddrPaths), matchingPath(u.Path, peerAsPaths):
-					log.V(1).Infof("Received update path: %s", prototext.Format(u))
-					shouldProcess = true
-				default:
-					log.V(1).Infof("goBgpTask: update path received isn't matched by any handlers: %s", prototext.Format(u.Path))
-				}
-			}
-			for _, u := range no.Delete {
-				log.V(1).Infof("Received delete path: %s", prototext.Format(u))
-				switch {
-				case len(u.Elem) > 0:
-				case len(u.Element) > 0: //nolint:staticcheck //lint:ignore SA1019 gnmi cache currently doesn't support PathElem for deletions.
-					// Since gNMI still sends delete paths using the deprecated Element field, we need to translate it into path-elems first.
-					// We also need to strip the first element for origin.
-					//nolint:staticcheck //lint:ignore SA1019 gnmi cache currently doesn't support PathElem for deletions.
-					elems, err := PathTranslator.PathElem(u.Element[1:])
-					if err != nil {
-						log.Errorf("goBgpTask: failed to translate delete path: %s", prototext.Format(u))
-						return
-					}
-					u.Elem = elems
-				default:
-					log.Errorf("Unhandled: delete at root: %s", prototext.Format(u))
-					return
-				}
-				switch {
-				case matchingPath(u, asPaths), matchingPath(u, routeIDPaths), matchingPath(u, neighAddrPaths), matchingPath(u, peerAsPaths):
-					shouldProcess = true
-				default:
-					log.V(1).Infof("goBgpTask: delete path received isn't matched by any handlers: %s", prototext.Format(u))
-				}
-			}
-
-			if !shouldProcess {
-				continue
-			}
-
-			intendedRoot := getIntendedConfig()
-			intended := intendedRoot.GetNetworkInstance("default").GetProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetBgp()
-			if intended == nil {
-				intended = &oc.NetworkInstance_Protocol_Bgp{}
-				intended.PopulateDefaults()
-			}
+			intended := rootVal.GetOrCreateNetworkInstance(DefaultNetworkInstance).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
 
 			processBgp := func() {
+				log.V(1).Info("Processing BGP update")
 				// Visit paths in action DAG order.
 				// - The output at each stage are
 				//   1. The GoBGP action to take.
@@ -241,7 +168,7 @@ func goBgpTask(getIntendedConfig func() *oc.Root, q gnmit.Queue, update gnmit.Up
 
 				// Action 1: StartBGP / StopBGP / no-op
 				//   - as-path, route-id
-				intendedGlobal, appliedGlobal := intended.GetGlobal(), appliedBgp.GetOrCreateGlobal()
+				intendedGlobal, appliedGlobal := intended.GetOrCreateGlobal(), appliedBgp.GetOrCreateGlobal()
 				if !reflect.DeepEqual(intendedGlobal.As, appliedGlobal.As) || !reflect.DeepEqual(intendedGlobal.RouterId, appliedGlobal.RouterId) {
 					switch {
 					case intendedGlobal.As == nil || intendedGlobal.RouterId == nil:
@@ -387,8 +314,15 @@ func goBgpTask(getIntendedConfig func() *oc.Root, q gnmit.Queue, update gnmit.Up
 				log.Errorf("goBgpTask: updating applied configuration failed")
 			}
 			appliedBgpMu.Unlock()
+
+			return ygnmi.Continue
+		},
+	)
+
+	go func() {
+		if _, err := bgpWatcher.Await(); err != nil {
+			log.Warningf("GoBGP Task's watcher has stopped: %v", err)
 		}
 	}()
-
 	return nil
 }

--- a/gnmi/fakedevice/gobgp.go
+++ b/gnmi/fakedevice/gobgp.go
@@ -92,7 +92,7 @@ func StartGoBGPTask(ctx context.Context, port int, target string, enableTLS bool
 			return false
 		}
 		if len(no.GetUpdate())+len(no.GetDelete()) > 0 {
-			_, err := gnmiclient.Update(ctx, yclient, bgpPath.State(), appliedBgp)
+			_, err := gnmiclient.Replace(ctx, yclient, bgpPath.State(), appliedBgp)
 			if err != nil {
 				log.Errorf("goBgpTask: error while writing update to applied configuration: %v", err)
 				return false

--- a/gnmi/gnmi.go
+++ b/gnmi/gnmi.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openconfig/lemming/gnmi/fakedevice"
 	"github.com/openconfig/lemming/gnmi/gnmit"
 	"github.com/openconfig/lemming/gnmi/oc"
 
@@ -45,7 +44,7 @@ func createGNMIServer(targetName string) (*gnmit.GNMIServer, error) {
 	if err := gnmit.SetupSchema(schema); err != nil {
 		return nil, fmt.Errorf("gnmi: cannot setup ygot schema object: %v", err)
 	}
-	_, gnmiServer, err := gnmit.NewServer(context.Background(), schema, targetName, false, fakedevice.Tasks(targetName))
+	_, gnmiServer, err := gnmit.NewServer(context.Background(), schema, targetName, false, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gNMI server: %v", err)
 	}

--- a/gnmi/gnmi.go
+++ b/gnmi/gnmi.go
@@ -44,7 +44,7 @@ func createGNMIServer(targetName string) (*gnmit.GNMIServer, error) {
 	if err := gnmit.SetupSchema(schema); err != nil {
 		return nil, fmt.Errorf("gnmi: cannot setup ygot schema object: %v", err)
 	}
-	_, gnmiServer, err := gnmit.NewServer(context.Background(), schema, targetName, false, nil)
+	_, gnmiServer, err := gnmit.NewServer(context.Background(), schema, targetName, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gNMI server: %v", err)
 	}

--- a/gnmi/gnmit/gnmit_test.go
+++ b/gnmi/gnmit/gnmit_test.go
@@ -149,7 +149,7 @@ func toUpd(r *gpb.SubscribeResponse) []*upd {
 // TestONCE tests the subscribe mode of gnmit.
 func TestONCE(t *testing.T) {
 	ctx := context.Background()
-	c, addr, err := New(ctx, nil, "localhost:0", "local", false, nil)
+	c, addr, err := New(ctx, nil, "localhost:0", "local", false)
 	if err != nil {
 		t.Fatalf("cannot start server, got err: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestONCESet(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
-	c, addr, err := NewSettable(ctx, "localhost:0", "local", false, schema, nil)
+	c, addr, err := NewSettable(ctx, "localhost:0", "local", false, schema)
 	if err != nil {
 		t.Fatalf("cannot start server, got err: %v", err)
 	}
@@ -348,7 +348,7 @@ func TestONCESetJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
-	c, addr, err := NewSettable(ctx, "localhost:0", "local", false, schema, nil)
+	c, addr, err := NewSettable(ctx, "localhost:0", "local", false, schema)
 	if err != nil {
 		t.Fatalf("cannot start server, got err: %v", err)
 	}
@@ -446,7 +446,7 @@ func TestONCESetJSON(t *testing.T) {
 // TestSTREAM tests the STREAM mode of gnmit.
 func TestSTREAM(t *testing.T) {
 	ctx := context.Background()
-	c, addr, err := New(ctx, nil, "localhost:0", "local", false, nil)
+	c, addr, err := New(ctx, nil, "localhost:0", "local", false)
 	if err != nil {
 		t.Fatalf("cannot start server, got err: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/openconfig/kne v0.1.6
 	github.com/openconfig/ondatra v0.0.0-20220916181150-cf83474b5941
 	github.com/openconfig/ygnmi v0.2.3
-	github.com/openconfig/ygot v0.25.0
+	github.com/openconfig/ygot v0.25.2
 	github.com/osrg/gobgp/v3 v3.5.0
 	github.com/p4lang/p4runtime v1.3.0
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/h-fam/errdiff v1.0.2
 	github.com/kentik/patricia v1.2.0
 	github.com/open-traffic-generator/snappi/gosnappi v0.9.4
-	github.com/openconfig/gnmi v0.0.0-20220617175856-41246b1b3507
+	github.com/openconfig/gnmi v0.0.0-20220920173703-480bf53a74d2
 	github.com/openconfig/gnoi v0.0.0-20220912141010-93cdd9ae9f35
 	github.com/openconfig/gnsi v0.0.0-20220906172358-1eda48d90de6
 	github.com/openconfig/goyang v1.1.0
@@ -19,7 +19,7 @@ require (
 	github.com/openconfig/kne v0.1.6
 	github.com/openconfig/ondatra v0.0.0-20220916181150-cf83474b5941
 	github.com/openconfig/ygnmi v0.2.3
-	github.com/openconfig/ygot v0.24.4
+	github.com/openconfig/ygot v0.25.0
 	github.com/osrg/gobgp/v3 v3.5.0
 	github.com/p4lang/p4runtime v1.3.0
 	github.com/spf13/pflag v1.0.5
@@ -97,7 +97,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/open-traffic-generator/ixia-c-operator v0.1.89 // indirect
 	github.com/openconfig/gocloser v0.0.0-20220310182203-c6c950ed3b0b // indirect
-	github.com/openconfig/grpctunnel v0.0.0-20220524190229-125331eabdde // indirect
+	github.com/openconfig/grpctunnel v0.0.0-20220819142823-6f5422b8ca70 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,8 @@ github.com/open-traffic-generator/snappi/gosnappi v0.9.4/go.mod h1:elsB41LK8QapL
 github.com/openconfig/gnmi v0.0.0-20200414194230-1597cc0f2600/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
 github.com/openconfig/gnmi v0.0.0-20200508230933-d19cebf5e7be/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
 github.com/openconfig/gnmi v0.0.0-20210527163611-d3a3e30199da/go.mod h1:H/20NXlnWbCPFC593nxpiKJ+OU//7mW7s7Qk7uVdg3Q=
-github.com/openconfig/gnmi v0.0.0-20220617175856-41246b1b3507 h1:tv9HygDMXnoGyWuLmNCodMV2+PK6+uT/ndAxDVzsUUQ=
-github.com/openconfig/gnmi v0.0.0-20220617175856-41246b1b3507/go.mod h1:ycJVRtLs20E2c1WD+9oacgxbrBFwQygd8/uaOuGMlfc=
+github.com/openconfig/gnmi v0.0.0-20220920173703-480bf53a74d2 h1:3YLlQFLDsFTvruKoYBbuYqhCgsXMtNewSrLjNXcF/Sg=
+github.com/openconfig/gnmi v0.0.0-20220920173703-480bf53a74d2/go.mod h1:Y9os75GmSkhHw2wX8sMsxfI7qRGAEcDh8NTa5a8vj6E=
 github.com/openconfig/gnoi v0.0.0-20220912141010-93cdd9ae9f35 h1:kII2ou2vVRBUcspciY+WcAwfGq3PHBJ9egErVt9XjX0=
 github.com/openconfig/gnoi v0.0.0-20220912141010-93cdd9ae9f35/go.mod h1:ZMRwQ7maVNSOjie3Jn67fW5WY7UDrFSiYSlV/GxthQs=
 github.com/openconfig/gnsi v0.0.0-20220906172358-1eda48d90de6 h1:AhSYbUpYERsQc30tc1hL1j2mMsUofaj1sTGeONjRph4=
@@ -549,8 +549,8 @@ github.com/openconfig/gribi v0.1.1-0.20220622162620-08d53dffce45/go.mod h1:VFqGH
 github.com/openconfig/gribigo v0.0.0-20220802181317-805e943d8714 h1:cSVvPluM/6nOX4YgCk+kdz3tbFRzn5bh60QglfgVFKM=
 github.com/openconfig/gribigo v0.0.0-20220802181317-805e943d8714/go.mod h1:RaHohUwqXt27CLnRu8aFOIFvpEgqPJGvKWil3eF1EyQ=
 github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d/go.mod h1:x9tAZ4EwqCQ0jI8D6S8Yhw9Z0ee7/BxWQX0k0Uib5Q8=
-github.com/openconfig/grpctunnel v0.0.0-20220524190229-125331eabdde h1:tSMKTQlWcHhdxQhn6P9myhLcoI+SzxF9e6hHWstCagU=
-github.com/openconfig/grpctunnel v0.0.0-20220524190229-125331eabdde/go.mod h1:OmTWe7RyZj2CIzIgy4ovEBzCLBJzRvWSZmn7u02U9gU=
+github.com/openconfig/grpctunnel v0.0.0-20220819142823-6f5422b8ca70 h1:t6SvvdfWCMlw0XPlsdxO8EgO+q/fXnTevDjdYREKFwU=
+github.com/openconfig/grpctunnel v0.0.0-20220819142823-6f5422b8ca70/go.mod h1:OmTWe7RyZj2CIzIgy4ovEBzCLBJzRvWSZmn7u02U9gU=
 github.com/openconfig/kne v0.1.6 h1:NcuRPSuvcbKHB+mWxztlQ8nuZRScMRsOX5T7s//jLXM=
 github.com/openconfig/kne v0.1.6/go.mod h1:Ua3W+2CbNsf8zk3v8KiFk7XUUN2ISYhvwjFXNqOpE2Y=
 github.com/openconfig/ondatra v0.0.0-20220916181150-cf83474b5941 h1:QNXDQvLPMCQkxBIT+QPFTGtu1DWNvoofxAAty7E9+Sc=
@@ -563,8 +563,8 @@ github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQS
 github.com/openconfig/ygot v0.10.4/go.mod h1:oCQNdXnv7dWc8scTDgoFkauv1wwplJn5HspHcjlxSAQ=
 github.com/openconfig/ygot v0.13.2/go.mod h1:kJN0yCXIH07dOXvNBEFm3XxXdnDD5NI6K99tnD5x49c=
 github.com/openconfig/ygot v0.20.0/go.mod h1:7ZiBFNc4n/1Hkv2v2dAEpxisqDznp0JVpLR13Toe4AY=
-github.com/openconfig/ygot v0.24.4 h1:/7uue5le3qQChGSST1eJx7J1u2Jh2WQ5ADJGvOqiqb4=
-github.com/openconfig/ygot v0.24.4/go.mod h1:6Ddz8kyEjK/c1e+rbShOTYLZdQmuk5ZJj6SJuwZp8u4=
+github.com/openconfig/ygot v0.25.0 h1:HOCeRj6YKNpMli9slPTnNxMkRogVdzVFWkhtWWZURuE=
+github.com/openconfig/ygot v0.25.0/go.mod h1:4RS8uxpdF7C+065KYhMwGOxNpu1jBIObglFljRQq50E=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQS
 github.com/openconfig/ygot v0.10.4/go.mod h1:oCQNdXnv7dWc8scTDgoFkauv1wwplJn5HspHcjlxSAQ=
 github.com/openconfig/ygot v0.13.2/go.mod h1:kJN0yCXIH07dOXvNBEFm3XxXdnDD5NI6K99tnD5x49c=
 github.com/openconfig/ygot v0.20.0/go.mod h1:7ZiBFNc4n/1Hkv2v2dAEpxisqDznp0JVpLR13Toe4AY=
-github.com/openconfig/ygot v0.25.0 h1:HOCeRj6YKNpMli9slPTnNxMkRogVdzVFWkhtWWZURuE=
-github.com/openconfig/ygot v0.25.0/go.mod h1:4RS8uxpdF7C+065KYhMwGOxNpu1jBIObglFljRQq50E=
+github.com/openconfig/ygot v0.25.2 h1:0AXBbCqANsY87yV2RaRTYtMVfjsprZx5EOF1jVNkum4=
+github.com/openconfig/ygot v0.25.2/go.mod h1:4RS8uxpdF7C+065KYhMwGOxNpu1jBIObglFljRQq50E=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=

--- a/integration_tests/twodut_tests/bgp_establish_test.go
+++ b/integration_tests/twodut_tests/bgp_establish_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openconfig/lemming/gnmi/fakedevice"
 	"github.com/openconfig/lemming/gnmi/oc"
 	"github.com/openconfig/lemming/gnmi/oc/ocpath"
 	"github.com/openconfig/ondatra"
@@ -116,7 +117,7 @@ func TestEstablish(t *testing.T) {
 	dut2 := ondatra.DUT(t, "dut2")
 	configureDUT(t, dut2, dut2Port1)
 
-	bgpPath := ocpath.Root().NetworkInstance("default").Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	bgpPath := ocpath.Root().NetworkInstance(fakedevice.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 
 	// Remove any existing BGP config
 	gnmi.Delete(t, dut, bgpPath.Config())

--- a/lemming.go
+++ b/lemming.go
@@ -151,7 +151,8 @@ func New(lis net.Listener, targetName string, opts ...grpc.ServerOption) (*Devic
 
 	fakedevice.StartSystemBaseTask(context.Background(), port, targetName, enableTLS)
 	fakedevice.StartBootTimeTask(context.Background(), port, targetName, enableTLS)
-	fakedevice.StartCurrentDateTimeTask(context.Background(), port, targetName, enableTLS)
+	//fakedevice.StartCurrentDateTimeTask(context.Background(), port, targetName, enableTLS)
+	fakedevice.StartGoBGPTask(context.Background(), port, targetName, enableTLS)
 
 	log.Info("lemming created")
 	return d, nil

--- a/lemming.go
+++ b/lemming.go
@@ -151,7 +151,6 @@ func New(lis net.Listener, targetName string, opts ...grpc.ServerOption) (*Devic
 
 	fakedevice.StartSystemBaseTask(context.Background(), port, targetName, enableTLS)
 	fakedevice.StartBootTimeTask(context.Background(), port, targetName, enableTLS)
-	//fakedevice.StartCurrentDateTimeTask(context.Background(), port, targetName, enableTLS)
 	fakedevice.StartGoBGPTask(context.Background(), port, targetName, enableTLS)
 
 	log.Info("lemming created")

--- a/sysrib/server.go
+++ b/sysrib/server.go
@@ -144,7 +144,7 @@ func (s *Server) monitorConnectedIntfs(port int, target string, enableTLS bool) 
 						s.setInterface(name, int32(ifindex), intf.GetEnabled())
 						// TODO(wenbli): Support other VRFs.
 						if subintf := intf.GetSubinterface(0); subintf != nil {
-							for _, addr := range subintf.GetIpv4().Address {
+							for _, addr := range subintf.GetOrCreateIpv4().Address {
 								if addr.Ip != nil && addr.PrefixLength != nil {
 									if err := s.addInterfacePrefix(name, int32(ifindex), fmt.Sprintf("%s/%d", addr.GetIp(), addr.GetPrefixLength()), defaultNI); err != nil {
 										log.Warningf("adding interface prefix failed: %v", err)

--- a/sysrib/server_test.go
+++ b/sysrib/server_test.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// Each quantum is 100 ms
-	maxGNMIWaitQuanta = 50
+	maxGNMIWaitQuanta = 100
 )
 
 type AddIntfAction struct {


### PR DESCRIPTION
Also fixed the following:
* Fixed TODO for op state datastore service. It now behaves the same way as the config datastore.
* Removed the Task interface. The boilerplate savings are substantial.
* Imported latest version of ygot to simply datastore's unmarshalling code.