### PR TITLE
Only use CacheClient as gNMI client helper.

### DIFF
--- a/gnmi/fakedevice/fakedevice.go
+++ b/gnmi/fakedevice/fakedevice.go
@@ -25,6 +25,8 @@ import (
 	"github.com/openconfig/lemming/gnmi/oc/ocpath"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot/pathtranslate"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
 const (
@@ -44,8 +46,8 @@ func init() {
 	}
 }
 
-func StartBootTimeTask(ctx context.Context, port int, target string, enableTLS bool) error {
-	yclient, err := gnmiclient.NewYGNMIClient(port, target, enableTLS)
+func StartBootTimeTask(ctx context.Context, gClient gpb.GNMIClient, target string) error {
+	yclient, err := ygnmi.NewClient(gClient, ygnmi.WithTarget(target))
 	if err != nil {
 		return err
 	}
@@ -55,8 +57,8 @@ func StartBootTimeTask(ctx context.Context, port int, target string, enableTLS b
 	return nil
 }
 
-func StartCurrentDateTimeTask(ctx context.Context, port int, target string, enableTLS bool) error {
-	yclient, err := gnmiclient.NewYGNMIClient(port, target, enableTLS)
+func StartCurrentDateTimeTask(ctx context.Context, gClient gpb.GNMIClient, target string) error {
+	yclient, err := ygnmi.NewClient(gClient, ygnmi.WithTarget(target))
 	if err != nil {
 		return err
 	}
@@ -86,8 +88,8 @@ func StartCurrentDateTimeTask(ctx context.Context, port int, target string, enab
 
 // StartSystemBaseTask handles some of the logic for the base systems feature
 // profile using ygnmi as the client.
-func StartSystemBaseTask(ctx context.Context, port int, target string, enableTLS bool) error {
-	yclient, err := gnmiclient.NewYGNMIClient(port, target, enableTLS)
+func StartSystemBaseTask(ctx context.Context, gClient gpb.GNMIClient, target string) error {
+	yclient, err := ygnmi.NewClient(gClient, ygnmi.WithTarget(target))
 	if err != nil {
 		return err
 	}

--- a/gnmi/fakedevice/gobgp.go
+++ b/gnmi/fakedevice/gobgp.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	log "github.com/golang/glog"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/lemming/gnmi/gnmiclient"
 	"github.com/openconfig/lemming/gnmi/oc"
 	"github.com/openconfig/lemming/gnmi/oc/ocpath"
@@ -52,8 +53,8 @@ const (
 //     When there is a dependency, the later actions will NOT directly depend on the results of the previous actions, but will just look at the current config view to determine the appropriate action.
 //     e.g. for peers, if the global setting has been set up, then we can create the peers and update the applied config if it succeeds, but if not then we don't do anything.
 //     ; however, if the global setting hasn't been set up, we actually need to erase the entirety of the applied config. This is because the watcher doesn't tell us this information.
-func StartGoBGPTask(ctx context.Context, port int, target string, enableTLS bool) error {
-	yclient, err := gnmiclient.NewYGNMIClient(port, target, enableTLS)
+func StartGoBGPTask(ctx context.Context, gClient gpb.GNMIClient, target string) error {
+	yclient, err := ygnmi.NewClient(gClient, ygnmi.WithTarget(target))
 	if err != nil {
 		return err
 	}

--- a/gnmi/gnmiclient/cache.go
+++ b/gnmi/gnmiclient/cache.go
@@ -36,16 +36,6 @@ func New(srv gpb.GNMIServer) (gpb.GNMIClient, error) {
 	}, nil
 }
 
-// NewReadOnly creates a config-based gNMI client for the gNMI cache.
-// The client calls the server gRPC implementation with a custom streaming gRPC implementation
-// in order to bypass the regular gRPC wire marshalling/unmarshalling handling.
-func NewReadOnly(srv gpb.GNMIServer) (gpb.GNMIClient, error) {
-	return &cacheClient{
-		gnmiMode: gnmistore.ConfigMode,
-		srv:      srv,
-	}, nil
-}
-
 // cacheClient is a gNMI client talks directly to a server, without sending messages over the wire.
 type cacheClient struct {
 	gpb.GNMIClient

--- a/gnmi/gnmiclient/cache.go
+++ b/gnmi/gnmiclient/cache.go
@@ -54,12 +54,12 @@ type cacheClient struct {
 }
 
 // Set uses the datastore client for Set, instead of the public cache endpoint.
-func (m *cacheClient) Set(ctx context.Context, in *gpb.SetRequest, _ ...grpc.CallOption) (*gpb.SetResponse, error) {
-	return m.srv.Set(metadata.NewIncomingContext(ctx, metadata.Pairs(gnmistore.GNMIModeMetadataKey, string(m.gnmiMode))), in)
+func (c *cacheClient) Set(ctx context.Context, in *gpb.SetRequest, _ ...grpc.CallOption) (*gpb.SetResponse, error) {
+	return c.srv.Set(metadata.NewIncomingContext(ctx, metadata.Pairs(gnmistore.GNMIModeMetadataKey, string(c.gnmiMode))), in)
 }
 
 // Subscribe implements gNMI Subscribe, by calling a gNMI server directly.
-func (cc *cacheClient) Subscribe(ctx context.Context, _ ...grpc.CallOption) (gpb.GNMI_SubscribeClient, error) {
+func (c *cacheClient) Subscribe(ctx context.Context, _ ...grpc.CallOption) (gpb.GNMI_SubscribeClient, error) {
 	errCh := make(chan error)
 	respCh := make(chan *gpb.SubscribeResponse, 10)
 	reqCh := make(chan *gpb.SubscribeRequest)
@@ -76,7 +76,7 @@ func (cc *cacheClient) Subscribe(ctx context.Context, _ ...grpc.CallOption) (gpb
 	}
 
 	go func() {
-		err := cc.srv.Subscribe(sub)
+		err := c.srv.Subscribe(sub)
 		errCh <- err
 	}()
 	return client, nil

--- a/lemming.go
+++ b/lemming.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/netip"
 	"sync"
 
 	"github.com/openconfig/lemming/dataplane"
@@ -97,16 +96,8 @@ func New(lis net.Listener, targetName string, opts ...grpc.ServerOption) (*Devic
 	}
 	reflection.Register(s)
 	d.startServer()
-	port, enableTLS := viper.GetInt("port"), viper.GetBool("enable_tls")
-	if port == 0 {
-		addrport, err := netip.ParseAddrPort(lis.Addr().String())
-		if err != nil {
-			return nil, err
-		}
-		port = int(addrport.Port())
-	}
 
-	cacheClient, err := gnmiclient.New(gnmiServer, port, enableTLS)
+	cacheClient, err := gnmiclient.New(gnmiServer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create local gNMI client: %v", err)
 	}

--- a/lemming.go
+++ b/lemming.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"os"
 	"sync"
 
 	"github.com/openconfig/lemming/dataplane"
@@ -38,7 +37,6 @@ import (
 	"k8s.io/klog/v2"
 
 	log "github.com/golang/glog"
-	zpb "github.com/openconfig/lemming/proto/sysrib"
 )
 
 // Device is the reference device implementation.
@@ -55,31 +53,6 @@ type Device struct {
 	mu      sync.Mutex
 	err     error
 	stopped chan struct{}
-}
-
-// startSysrib starts the sysrib gRPC service at a unix domain socket. This
-// should be started prior to routing services to allow them to connect to
-// sysrib during their initialization.
-func startSysrib(dataplane *sysrib.Dataplane, port int, target string, enableTLS bool) {
-	if err := os.RemoveAll(sysrib.SockAddr); err != nil {
-		log.Fatal(err)
-	}
-
-	lis, err := net.Listen("unix", sysrib.SockAddr)
-	if err != nil {
-		log.Fatalf("listen error: %v", err)
-	}
-
-	grpcServer := grpc.NewServer()
-	s, err := sysrib.NewServer(dataplane, port, target, enableTLS)
-	if err != nil {
-		log.Fatalf("error while creating sysrib server: %v", err)
-	}
-	zpb.RegisterSysribServer(grpcServer, s)
-
-	go func() {
-		grpcServer.Serve(lis)
-	}()
 }
 
 // New returns a new initialized device.
@@ -133,22 +106,29 @@ func New(lis net.Listener, targetName string, opts ...grpc.ServerOption) (*Devic
 		port = int(addrport.Port())
 	}
 
+	cacheClient, err := gnmiclient.New(gnmiServer, port, enableTLS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local gNMI client: %v", err)
+	}
+
 	if dplane != nil {
-		gnmiClient, err := gnmiclient.NewLocal(port, enableTLS)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create local client: %v", err)
-		}
-		if err := dplane.Start(context.Background(), gnmiclient.NewCacheClient(gnmiServer, gnmiClient), targetName); err != nil {
+		if err := dplane.Start(context.Background(), cacheClient, targetName); err != nil {
 			return nil, err
 		}
 	}
 
 	log.Infof("starting sysrib")
-	startSysrib(sysDataplane, port, targetName, enableTLS)
+	sysribServer, err := sysrib.New(sysDataplane)
+	if err != nil {
+		return nil, err
+	}
+	if err := sysribServer.Start(cacheClient, targetName); err != nil {
+		return nil, err
+	}
 
-	fakedevice.StartSystemBaseTask(context.Background(), port, targetName, enableTLS)
-	fakedevice.StartBootTimeTask(context.Background(), port, targetName, enableTLS)
-	fakedevice.StartGoBGPTask(context.Background(), port, targetName, enableTLS)
+	fakedevice.StartSystemBaseTask(context.Background(), cacheClient, targetName)
+	fakedevice.StartBootTimeTask(context.Background(), cacheClient, targetName)
+	fakedevice.StartGoBGPTask(context.Background(), cacheClient, targetName)
 
 	log.Info("lemming created")
 	return d, nil

--- a/sysrib/server_test.go
+++ b/sysrib/server_test.go
@@ -120,22 +120,23 @@ func checkResolvedRoutesEqual(got, want []*ResolvedRoute) error {
 	return nil
 }
 
-func mustPath(s string) *gpb.Path {
-	p, err := ygot.StringToStructuredPath(s)
-	if err != nil {
-		panic(fmt.Sprintf("cannot parse subscription path %s, %v", s, err))
-	}
-	return p
-}
-
+// TODO(wenbli): Use this when https://github.com/openconfig/lemming/issues/67 is fixed.
+// func mustPath(s string) *gpb.Path {
+// 	p, err := ygot.StringToStructuredPath(s)
+// 	if err != nil {
+// 		panic(fmt.Sprintf("cannot parse subscription path %s, %v", s, err))
+// 	}
+// 	return p
+// }
+//
 // Disable linter for this helper function.
 //
 //nolint:unparam
-func mustTargetPath(t, s string) *gpb.Path {
-	p := mustPath(s)
-	p.Target = t
-	return p
-}
+// func mustTargetPath(t, s string) *gpb.Path {
+// 	p := mustPath(s)
+// 	p.Target = t
+// 	return p
+// }
 
 func mustPSPath(ps ygnmi.PathStruct) *gpb.Path {
 	p, _, err := ygnmi.ResolvePath(ps)
@@ -827,12 +828,11 @@ func TestServer(t *testing.T) {
 				// }
 				intfPath := mustPSPath(ocpath.Root().Interface(intf.name))
 				intfPath.Target = "local"
-				//fmt.Println(updates)
 				if _, err := client.Set(context.Background(), &gpb.SetRequest{
 					Prefix: intfPath,
-					//Delete: []*gpb.Path{
-					//	mustPSPath(ocpath.Root()),
-					//},
+					Delete: []*gpb.Path{
+						mustPSPath(ocpath.Root()),
+					},
 					Update: updates,
 					// TODO(wenbli): Use this when https://github.com/openconfig/lemming/issues/67 is fixed.
 					// Prefix: mustTargetPath("local", "")

--- a/sysrib/server_test.go
+++ b/sysrib/server_test.go
@@ -768,7 +768,7 @@ func TestServer(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			// TODO(wenbli): Don't re-create gNMI server, simply erase it and then reconnect to it afterwards.
 			grpcServer := grpc.NewServer()
-			_, err := gnmi.New(grpcServer, "local")
+			gnmiServer, err := gnmi.New(grpcServer, "local")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -786,15 +786,19 @@ func TestServer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			s, err := NewServer(dp, int(addrport.Port()), "local", false)
+			s, err := New(dp)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// Update the interface configuration on the gNMI server.
-			client, err := gnmiclient.NewLocal(int(addrport.Port()), false)
+			client, err := gnmiclient.New(gnmiServer, int(addrport.Port()), false)
 			if err != nil {
 				t.Fatalf("cannot dial gNMI datastore server, %v", err)
+			}
+
+			if err := s.Start(client, "local"); err != nil {
+				t.Fatalf("cannot start sysrib server, %v", err)
 			}
 
 			for _, intf := range tt.inInterfaces {


### PR DESCRIPTION
Refactored existing code to use the same pattern as the dataplane for using this helper.