### PR TITLE
Refactor gnmit

### DIFF
--- a/gnmi/gnmi.go
+++ b/gnmi/gnmi.go
@@ -37,14 +37,15 @@ type Server struct {
 }
 
 func createGNMIServer(targetName string) (*gnmit.GNMIServer, error) {
-	schema, err := oc.Schema()
+	configSchema, err := oc.Schema()
 	if err != nil {
 		return nil, fmt.Errorf("cannot create ygot schema object: %v", err)
 	}
-	if err := gnmit.SetupSchema(schema); err != nil {
-		return nil, fmt.Errorf("gnmi: cannot setup ygot schema object: %v", err)
+	stateSchema, err := oc.Schema()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create ygot schema object: %v", err)
 	}
-	_, gnmiServer, err := gnmit.NewServer(context.Background(), schema, targetName, false)
+	_, gnmiServer, err := gnmit.New(context.Background(), configSchema, stateSchema, targetName, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gNMI server: %v", err)
 	}

--- a/gnmi/gnmit/collector.go
+++ b/gnmi/gnmit/collector.go
@@ -1,0 +1,114 @@
+package gnmit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openconfig/gnmi/cache"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/gnmi/subscribe"
+)
+
+var (
+	// metadataUpdatePeriod is the period of time after which the metadata for the collector
+	// is updated to the client.
+	metadataUpdatePeriod = 30 * time.Second
+	// sizeUpdatePeriod is the period of time after which the storage size information for
+	// the collector is updated to the client.
+	sizeUpdatePeriod = 30 * time.Second
+)
+
+// Collector is a basic gNMI target that supports only the Subscribe
+// RPC, and acts as a cache for exactly one target.
+type Collector struct {
+	cache *cache.Cache
+	// name is the hostname of the client.
+	name string
+	// inCh is a channel use to write new SubscribeResponses to the client.
+	inCh chan *gpb.SubscribeResponse
+	// stopFn is the function used to stop the server.
+	stopFn func()
+}
+
+// NewCollector returns an initialized Collector.
+func NewCollector(hostname string) *Collector {
+	return &Collector{
+		cache: cache.New([]string{hostname}),
+		name:  hostname,
+		inCh:  make(chan *gpb.SubscribeResponse),
+	}
+}
+
+// Start starts the collector and returns a linked subscribe server.
+func (c *Collector) Start(ctx context.Context, sendMeta bool) (*subscribe.Server, error) {
+	t := c.cache.GetTarget(c.name)
+
+	subscribeSrv, err := subscribe.NewServer(c.cache)
+	if err != nil {
+		return nil, fmt.Errorf("could not instantiate gNMI server: %v", err)
+	}
+	c.cache.SetClient(subscribeSrv.Update)
+
+	if sendMeta {
+		go periodic(metadataUpdatePeriod, c.cache.UpdateMetadata)
+		go periodic(sizeUpdatePeriod, c.cache.UpdateSize)
+	}
+	t.Connect()
+
+	// start our single collector from the input channel.
+	go func() {
+		for {
+			select {
+			case msg := <-c.inCh:
+				if err := c.handleUpdate(msg); err != nil {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return subscribeSrv, nil
+}
+
+// TargetUpdate provides an input gNMI SubscribeResponse to update the
+// cache and clients with.
+func (c *Collector) TargetUpdate(m *gpb.SubscribeResponse) {
+	c.inCh <- m
+}
+
+// Stop halts the running collector.
+func (c *Collector) Stop() {
+	c.stopFn()
+}
+
+// handleUpdate handles an input gNMI SubscribeResponse that is received by
+// the target.
+func (c *Collector) handleUpdate(resp *gpb.SubscribeResponse) error {
+	t := c.cache.GetTarget(c.name)
+	switch v := resp.Response.(type) {
+	case *gpb.SubscribeResponse_Update:
+		return t.GnmiUpdate(v.Update)
+	case *gpb.SubscribeResponse_SyncResponse:
+		t.Sync()
+	case *gpb.SubscribeResponse_Error:
+		return fmt.Errorf("error in response: %s", v)
+	default:
+		return fmt.Errorf("unknown response %T: %s", v, v)
+	}
+	return nil
+}
+
+// periodic runs the function fn every period.
+func periodic(period time.Duration, fn func()) {
+	if period == 0 {
+		return
+	}
+	t := time.NewTicker(period)
+	defer t.Stop()
+	for range t.C {
+		fn()
+	}
+}

--- a/gnmi/gnmit/collector.go
+++ b/gnmi/gnmit/collector.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gnmit
 
 import (
@@ -23,7 +37,7 @@ var (
 // RPC, and acts as a cache for exactly one target.
 type Collector struct {
 	cache *cache.Cache
-	// name is the hostname of the client.
+	// name is the cache target name.
 	name string
 	// inCh is a channel use to write new SubscribeResponses to the client.
 	inCh chan *gpb.SubscribeResponse
@@ -31,16 +45,19 @@ type Collector struct {
 	stopFn func()
 }
 
-// NewCollector returns an initialized Collector.
-func NewCollector(hostname string) *Collector {
+// NewCollector returns an initialized gNMI Collector implementation.
+//
+// To create a gNMI server that supports gnmi.Set as well, use New() instead.
+func NewCollector(targetName string) *Collector {
 	return &Collector{
-		cache: cache.New([]string{hostname}),
-		name:  hostname,
+		cache: cache.New([]string{targetName}),
+		name:  targetName,
 		inCh:  make(chan *gpb.SubscribeResponse),
 	}
 }
 
-// Start starts the collector and returns a linked subscribe server.
+// Start starts the collector and returns a linked gNMI server that supports
+// gnmi.Subscribe.
 func (c *Collector) Start(ctx context.Context, sendMeta bool) (*subscribe.Server, error) {
 	t := c.cache.GetTarget(c.name)
 

--- a/gnmi/gnmit/gnmit.go
+++ b/gnmi/gnmit/gnmit.go
@@ -61,10 +61,10 @@ type GNMIServer struct {
 //
 // - configSchema is the specification of the schema if gnmi.Set on config paths is used.
 // - stateSchema is the specification of the schema if gnmi.Set on state paths is used.
-// - hostname is the name of the target.
+// - targetName is the name of the target.
 // - sendMeta indicates whether metadata should be sent
-func New(ctx context.Context, configSchema *ytypes.Schema, stateSchema *ytypes.Schema, hostname string, sendMeta bool) (*Collector, *GNMIServer, error) {
-	c := NewCollector(hostname)
+func New(ctx context.Context, configSchema *ytypes.Schema, stateSchema *ytypes.Schema, targetName string, sendMeta bool) (*Collector, *GNMIServer, error) {
+	c := NewCollector(targetName)
 	subscribeSrv, err := c.Start(ctx, sendMeta)
 	if err != nil {
 		return nil, nil, err
@@ -78,14 +78,14 @@ func New(ctx context.Context, configSchema *ytypes.Schema, stateSchema *ytypes.S
 		if err := ygot.PruneConfigFalse(configSchema.RootSchema(), configSchema.Root); err != nil {
 			return nil, nil, fmt.Errorf("gnmit: %v", err)
 		}
-		updateCache(c.cache, configSchema.Root, nil, hostname, OpenconfigOrigin, true)
+		updateCache(c.cache, configSchema.Root, nil, targetName, OpenconfigOrigin, true)
 	}
 
 	if stateSchema != nil {
 		if err := SetupSchema(stateSchema); err != nil {
 			return nil, nil, err
 		}
-		updateCache(c.cache, stateSchema.Root, nil, hostname, OpenconfigOrigin, true)
+		updateCache(c.cache, stateSchema.Root, nil, targetName, OpenconfigOrigin, true)
 	}
 
 	gnmiserver := &GNMIServer{

--- a/gnmi/gnmit/gnmit_test.go
+++ b/gnmi/gnmit/gnmit_test.go
@@ -149,7 +149,11 @@ func toUpd(r *gpb.SubscribeResponse) []*upd {
 // TestONCE tests the subscribe mode of gnmit.
 func TestONCE(t *testing.T) {
 	ctx := context.Background()
-	c, addr, err := New(ctx, nil, "localhost:0", "local", false)
+	c, gnmiServer, err := New(ctx, nil, nil, "local", false)
+	if err != nil {
+		t.Fatalf("cannot create server, got err: %v", err)
+	}
+	addr, err := gnmiServer.Start(ctx, "localhost:0")
 	if err != nil {
 		t.Fatalf("cannot start server, got err: %v", err)
 	}
@@ -250,7 +254,11 @@ func TestONCESet(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
-	c, addr, err := NewSettable(ctx, "localhost:0", "local", false, schema)
+	c, gnmiServer, err := New(ctx, schema, nil, "local", false)
+	if err != nil {
+		t.Fatalf("cannot create server, got err: %v", err)
+	}
+	addr, err := gnmiServer.Start(ctx, "localhost:0")
 	if err != nil {
 		t.Fatalf("cannot start server, got err: %v", err)
 	}
@@ -348,7 +356,11 @@ func TestONCESetJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
-	c, addr, err := NewSettable(ctx, "localhost:0", "local", false, schema)
+	c, gnmiServer, err := New(ctx, schema, nil, "local", false)
+	if err != nil {
+		t.Fatalf("cannot create server, got err: %v", err)
+	}
+	addr, err := gnmiServer.Start(ctx, "localhost:0")
 	if err != nil {
 		t.Fatalf("cannot start server, got err: %v", err)
 	}
@@ -446,7 +458,11 @@ func TestONCESetJSON(t *testing.T) {
 // TestSTREAM tests the STREAM mode of gnmit.
 func TestSTREAM(t *testing.T) {
 	ctx := context.Background()
-	c, addr, err := New(ctx, nil, "localhost:0", "local", false)
+	c, gnmiServer, err := New(ctx, nil, nil, "local", false)
+	if err != nil {
+		t.Fatalf("cannot create server, got err: %v", err)
+	}
+	addr, err := gnmiServer.Start(ctx, "localhost:0")
 	if err != nil {
 		t.Fatalf("cannot start server, got err: %v", err)
 	}


### PR DESCRIPTION
gnmit.New() is the function to call. I didn't remove gnmi/ since as it is it is agnostic to which generated ygot GoStruct it's using, and gnmi/ calls `oc.Schema()` to specify that. This way other repos can use it too.