### PR TITLE
Query and Update Packet Counters (in-pkt/out-pkt)

### DIFF
--- a/dataplane/handlers/interface.go
+++ b/dataplane/handlers/interface.go
@@ -133,8 +133,24 @@ func (ni *Interface) Start(ctx context.Context) error {
 		}
 	}()
 
-	// Gothread for updating counters.
+	ni.startCounterUpdates(ctx)
+
+	return nil
+}
+
+// Stop stops all watchers.
+func (ni *Interface) Stop() {
+	// TODO: prevent stopping more than once.
+	for _, closeFn := range ni.closers {
+		closeFn()
+	}
+}
+
+// startCounterUpdates starts a goroutine for updating counters for configured
+// interfaces.
+func (ni *Interface) startCounterUpdates(ctx context.Context) {
 	tick := time.NewTicker(time.Second)
+	ni.closers = append(ni.closers, tick.Stop)
 	go func() {
 		// Design comment:
 		// This polling can be eliminated if either the forwarding
@@ -178,16 +194,6 @@ func (ni *Interface) Start(ctx context.Context) error {
 			}
 		}
 	}()
-
-	return nil
-}
-
-// Stop stops all watchers.
-func (ni *Interface) Stop() {
-	// TODO: prevent stopping more than once.
-	for _, closeFn := range ni.closers {
-		closeFn()
-	}
 }
 
 // reconcile compares the interface config with state and modifies state to match config.

--- a/dataplane/internal/engine/port.go
+++ b/dataplane/internal/engine/port.go
@@ -43,7 +43,7 @@ func CreateExternalPort(ctx context.Context, c fwdpb.ServiceClient, name string)
 		return err
 	}
 	update := &fwdpb.PortUpdateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		PortId:    &fwdpb.PortId{ObjectId: &fwdpb.ObjectId{Id: name}},
 		Update: &fwdpb.PortUpdateDesc{
 			Port: &fwdpb.PortUpdateDesc_Kernel{
@@ -94,7 +94,7 @@ func CreateLocalPort(ctx context.Context, c fwdpb.ServiceClient, name string, fd
 		return err
 	}
 	update := &fwdpb.PortUpdateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		PortId:    &fwdpb.PortId{ObjectId: &fwdpb.ObjectId{Id: name}},
 		Update: &fwdpb.PortUpdateDesc{
 			Port: &fwdpb.PortUpdateDesc_Kernel{
@@ -127,7 +127,7 @@ func CreateLocalPort(ctx context.Context, c fwdpb.ServiceClient, name string, fd
 // createKernelPort creates a port using the "Kernel" dataplane type (socket API).
 func createKernelPort(ctx context.Context, c fwdpb.ServiceClient, name string) error {
 	port := &fwdpb.PortCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		Port: &fwdpb.PortDesc{
 			PortType: fwdpb.PortType_PORT_TYPE_KERNEL,
 			PortId: &fwdpb.PortId{
@@ -162,7 +162,7 @@ func createKernelPort(ctx context.Context, c fwdpb.ServiceClient, name string) e
 // createKernelPort creates a port using the "TAP" dataplane type (tap file API) and returns the fd to read/write from.
 func createTapPort(ctx context.Context, c fwdpb.ServiceClient, name string, fd int) error {
 	port := &fwdpb.PortCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		Port: &fwdpb.PortDesc{
 			PortType: fwdpb.PortType_PORT_TYPE_TAP,
 			PortId: &fwdpb.PortId{

--- a/dataplane/internal/engine/table.go
+++ b/dataplane/internal/engine/table.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	contextID        = "default"
+	DefaultContextID = "default"
 	fibV4Table       = "fib-v4"
 	fibV6Table       = "fib-v6"
 	srcMACTable      = "port-mac"
@@ -52,14 +52,14 @@ func mustParseHex(hexStr string) []byte {
 // SetupForwardingTables creates the forwarding tables.
 func SetupForwardingTables(ctx context.Context, c fwdpb.ServiceClient) error {
 	_, err := c.ContextCreate(context.Background(), &fwdpb.ContextCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 	})
 	if err != nil {
 		return err
 	}
 
 	v4FIB := &fwdpb.TableCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		Desc: &fwdpb.TableDesc{
 			TableType: fwdpb.TableType_TABLE_TYPE_PREFIX,
 			TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: fibV4Table}},
@@ -79,7 +79,7 @@ func SetupForwardingTables(ctx context.Context, c fwdpb.ServiceClient) error {
 		return err
 	}
 	v6FIB := &fwdpb.TableCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		Desc: &fwdpb.TableDesc{
 			TableType: fwdpb.TableType_TABLE_TYPE_PREFIX,
 			TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: fibV6Table}},
@@ -99,7 +99,7 @@ func SetupForwardingTables(ctx context.Context, c fwdpb.ServiceClient) error {
 		return err
 	}
 	portMAC := &fwdpb.TableCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		Desc: &fwdpb.TableDesc{
 			TableType: fwdpb.TableType_TABLE_TYPE_EXACT,
 			TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: srcMACTable}},
@@ -119,7 +119,7 @@ func SetupForwardingTables(ctx context.Context, c fwdpb.ServiceClient) error {
 		return err
 	}
 	neighbor := &fwdpb.TableCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		Desc: &fwdpb.TableDesc{
 			TableType: fwdpb.TableType_TABLE_TYPE_EXACT,
 			TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: neighborTable}},
@@ -159,7 +159,7 @@ func createFIBSelector(ctx context.Context, c fwdpb.ServiceClient) error {
 	}
 
 	etherType := &fwdpb.TableCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		Desc: &fwdpb.TableDesc{
 			TableType: fwdpb.TableType_TABLE_TYPE_EXACT,
 			TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: fibSelectorTable}},
@@ -175,7 +175,7 @@ func createFIBSelector(ctx context.Context, c fwdpb.ServiceClient) error {
 		return err
 	}
 	entries := &fwdpb.TableEntryAddRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		TableId: &fwdpb.TableId{
 			ObjectId: &fwdpb.ObjectId{
 				Id: fibSelectorTable,
@@ -230,7 +230,7 @@ func createFIBSelector(ctx context.Context, c fwdpb.ServiceClient) error {
 // createLayer2PuntTable creates a table to packets to punt at layer 2 (input port and mac dst).
 func createLayer2PuntTable(ctx context.Context, c fwdpb.ServiceClient) error {
 	arp := &fwdpb.TableCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		Desc: &fwdpb.TableDesc{
 			TableType: fwdpb.TableType_TABLE_TYPE_EXACT,
 			TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: arpPuntTable}},
@@ -250,7 +250,7 @@ func createLayer2PuntTable(ctx context.Context, c fwdpb.ServiceClient) error {
 		return err
 	}
 	entries := &fwdpb.TableEntryAddRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		TableId: &fwdpb.TableId{
 			ObjectId: &fwdpb.ObjectId{
 				Id: arpPuntTable,
@@ -282,7 +282,7 @@ func createLayer2PuntTable(ctx context.Context, c fwdpb.ServiceClient) error {
 		return err
 	}
 	layer2 := &fwdpb.TableCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		Desc: &fwdpb.TableDesc{
 			TableType: fwdpb.TableType_TABLE_TYPE_PREFIX,
 			TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: layer2PuntTable}},
@@ -321,7 +321,7 @@ func addLayer2PuntRule(ctx context.Context, c fwdpb.ServiceClient, portID uint64
 	binary.BigEndian.PutUint64(nidBytes, portID)
 
 	entries := &fwdpb.TableEntryAddRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		TableId: &fwdpb.TableId{
 			ObjectId: &fwdpb.ObjectId{
 				Id: layer2PuntTable,
@@ -366,7 +366,7 @@ func addLayer2PuntRule(ctx context.Context, c fwdpb.ServiceClient, portID uint64
 // createLayer3PuntTable creates a table controlling whether packets to punt at layer 3 (input port and IP dst).
 func createLayer3PuntTable(ctx context.Context, c fwdpb.ServiceClient) error {
 	multicast := &fwdpb.TableCreateRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		Desc: &fwdpb.TableDesc{
 			TableType: fwdpb.TableType_TABLE_TYPE_EXACT,
 			TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: layer3PuntTable}},
@@ -404,7 +404,7 @@ func AddLayer3PuntRule(ctx context.Context, c fwdpb.ServiceClient, portName stri
 	log.Infof("adding layer3 punt rule: portName %s, id %d, ip %v", portName, portID, ip)
 
 	entries := &fwdpb.TableEntryAddRequest{
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		TableId: &fwdpb.TableId{
 			ObjectId: &fwdpb.ObjectId{
 				Id: layer3PuntTable,
@@ -490,7 +490,7 @@ func AddIPRoute(ctx context.Context, c fwdpb.ServiceClient, v4 bool, ip, mask, n
 
 	entry := &fwdpb.TableEntryAddRequest{
 		TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: fib}},
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		EntryDesc: &fwdpb.EntryDesc{
 			Entry: &fwdpb.EntryDesc_Prefix{
 				Prefix: &fwdpb.PrefixEntryDesc{
@@ -535,7 +535,7 @@ func DeleteIPRoute(ctx context.Context, c fwdpb.ServiceClient, v4 bool, ip, mask
 	}
 	entry := &fwdpb.TableEntryRemoveRequest{
 		TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: fib}},
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		EntryDesc: &fwdpb.EntryDesc{
 			Entry: &fwdpb.EntryDesc_Prefix{
 				Prefix: &fwdpb.PrefixEntryDesc{
@@ -559,7 +559,7 @@ func DeleteIPRoute(ctx context.Context, c fwdpb.ServiceClient, v4 bool, ip, mask
 func AddNeighbor(ctx context.Context, c fwdpb.ServiceClient, ip, mac []byte) error {
 	entry := &fwdpb.TableEntryAddRequest{
 		TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: neighborTable}},
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		EntryDesc: &fwdpb.EntryDesc{
 			Entry: &fwdpb.EntryDesc_Exact{
 				Exact: &fwdpb.ExactEntryDesc{
@@ -596,7 +596,7 @@ func AddNeighbor(ctx context.Context, c fwdpb.ServiceClient, ip, mac []byte) err
 func RemoveNeighbor(ctx context.Context, c fwdpb.ServiceClient, ip []byte) error {
 	entry := &fwdpb.TableEntryRemoveRequest{
 		TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: neighborTable}},
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		EntryDesc: &fwdpb.EntryDesc{
 			Entry: &fwdpb.EntryDesc_Exact{
 				Exact: &fwdpb.ExactEntryDesc{
@@ -624,7 +624,7 @@ func UpdatePortSrcMAC(ctx context.Context, c fwdpb.ServiceClient, portName strin
 
 	entry := &fwdpb.TableEntryAddRequest{
 		TableId:   &fwdpb.TableId{ObjectId: &fwdpb.ObjectId{Id: srcMACTable}},
-		ContextId: &fwdpb.ContextId{Id: contextID},
+		ContextId: &fwdpb.ContextId{Id: DefaultContextID},
 		EntryDesc: &fwdpb.EntryDesc{
 			Entry: &fwdpb.EntryDesc_Exact{
 				Exact: &fwdpb.ExactEntryDesc{

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openconfig/gribi v0.1.1-0.20220622162620-08d53dffce45
 	github.com/openconfig/gribigo v0.0.0-20220802181317-805e943d8714
 	github.com/openconfig/kne v0.1.6
-	github.com/openconfig/ondatra v0.0.0-20220929172429-33fca1f76cf5
+	github.com/openconfig/ondatra v0.0.0-20220916181150-cf83474b5941
 	github.com/openconfig/ygnmi v0.3.1
 	github.com/openconfig/ygot v0.25.2
 	github.com/osrg/gobgp/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -552,8 +552,8 @@ github.com/openconfig/grpctunnel v0.0.0-20220819142823-6f5422b8ca70 h1:t6SvvdfWC
 github.com/openconfig/grpctunnel v0.0.0-20220819142823-6f5422b8ca70/go.mod h1:OmTWe7RyZj2CIzIgy4ovEBzCLBJzRvWSZmn7u02U9gU=
 github.com/openconfig/kne v0.1.6 h1:NcuRPSuvcbKHB+mWxztlQ8nuZRScMRsOX5T7s//jLXM=
 github.com/openconfig/kne v0.1.6/go.mod h1:Ua3W+2CbNsf8zk3v8KiFk7XUUN2ISYhvwjFXNqOpE2Y=
-github.com/openconfig/ondatra v0.0.0-20220929172429-33fca1f76cf5 h1:BgaEjkK/6WiHzMoaPH/qOEsUeksLQg8/Q35IH34Sicc=
-github.com/openconfig/ondatra v0.0.0-20220929172429-33fca1f76cf5/go.mod h1:/SUVxpkF/DwEx2+KBcW6Gy88IRxE8bVyx4K2nmi/PE4=
+github.com/openconfig/ondatra v0.0.0-20220916181150-cf83474b5941 h1:QNXDQvLPMCQkxBIT+QPFTGtu1DWNvoofxAAty7E9+Sc=
+github.com/openconfig/ondatra v0.0.0-20220916181150-cf83474b5941/go.mod h1:/SUVxpkF/DwEx2+KBcW6Gy88IRxE8bVyx4K2nmi/PE4=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07 h1:X631iD/B0ximGFb5P9LY5wHju4SiedxUhc5UZEo7VSw=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07/go.mod h1:bmpU0kIsCiXuncozViVuQx1HqolC3C94H7lD9KKmoTo=
 github.com/openconfig/ygnmi v0.3.1 h1:ZJL6vCvwYpRatdMP/ikax2uyz7XGunKp+E69ZqzvvHc=

--- a/integration_tests/traffic_test.go
+++ b/integration_tests/traffic_test.go
@@ -221,7 +221,7 @@ func awaitTimeout(ctx context.Context, c *fluent.GRIBIClient, t testing.TB, time
 }
 
 // testCounters test packet counters and should be called after testTraffic
-func testCounters(t *testing.T, ate *ondatra.ATEDevice, dut *ondatra.DUTDevice, wantTxPkts, wantRxPkts uint64) {
+func testCounters(t *testing.T, dut *ondatra.DUTDevice, wantTxPkts, wantRxPkts uint64) {
 	got := gnmi.Get(t, dut, ocpath.Root().Interface(dut.Port(t, "port1").Name()).Counters().InPkts().State())
 	t.Logf("DUT port 1 in-pkts: %d", got)
 	if got < wantTxPkts {
@@ -369,7 +369,7 @@ func TestIPv4Entry(t *testing.T) {
 			// counters are not erased, so have to accumulate the packets from previous subtests.
 			txPkts += otg.Telemetry().Flow("Flow").Counters().OutPkts().Get(t)
 			rxPkts += otg.Telemetry().Flow("Flow").Counters().InPkts().Get(t)
-			testCounters(t, ate, dut, txPkts, rxPkts)
+			testCounters(t, dut, txPkts, rxPkts)
 
 			gribic.Flush(context.Background(), &gribipb.FlushRequest{
 				NetworkInstance: &gribipb.FlushRequest_All{All: &gribipb.Empty{}},

--- a/integration_tests/traffic_test.go
+++ b/integration_tests/traffic_test.go
@@ -220,6 +220,21 @@ func awaitTimeout(ctx context.Context, c *fluent.GRIBIClient, t testing.TB, time
 	return c.Await(subctx, t)
 }
 
+// testCounters test packet counters and should be called after testTraffic
+func testCounters(t *testing.T, ate *ondatra.ATEDevice, dut *ondatra.DUTDevice, wantTxPkts, wantRxPkts uint64) {
+	got := gnmi.Get(t, dut, ocpath.Root().Interface(dut.Port(t, "port1").Name()).Counters().InPkts().State())
+	t.Logf("DUT port 1 in-pkts: %d", got)
+	if got < wantTxPkts {
+		t.Errorf("DUT got less packets (%d) than OTG sent (%d)", got, wantTxPkts)
+	}
+
+	got = gnmi.Get(t, dut, ocpath.Root().Interface(dut.Port(t, "port2").Name()).Counters().OutPkts().State())
+	t.Logf("DUT port 2 out-pkts: %d", got)
+	if got < wantRxPkts {
+		t.Errorf("DUT got sent less packets (%d) than OTG received (%d)", got, wantRxPkts)
+	}
+}
+
 // TestIPv4Entry tests a single IPv4Entry forwarding entry.
 func TestIPv4Entry(t *testing.T) {
 	ctx := context.Background()
@@ -314,6 +329,7 @@ func TestIPv4Entry(t *testing.T) {
 		},
 	}}
 	for _, tc := range cases {
+		var txPkts, rxPkts uint64
 		t.Run(tc.desc, func(t *testing.T) {
 			gribic := dut.RawAPIs().GRIBI().Default(t)
 			c := fluent.NewClient()
@@ -348,6 +364,13 @@ func TestIPv4Entry(t *testing.T) {
 			if loss > 1 {
 				t.Errorf("Loss: got %g, want <= 1", loss)
 			}
+
+			otg := ate.OTG()
+			// counters are not erased, so have to accumulate the packets from previous subtests.
+			txPkts += otg.Telemetry().Flow("Flow").Counters().OutPkts().Get(t)
+			rxPkts += otg.Telemetry().Flow("Flow").Counters().InPkts().Get(t)
+			testCounters(t, ate, dut, txPkts, rxPkts)
+
 			gribic.Flush(context.Background(), &gribipb.FlushRequest{
 				NetworkInstance: &gribipb.FlushRequest_All{All: &gribipb.Empty{}},
 			})

--- a/proto/forwarding/forwarding_common.proto
+++ b/proto/forwarding/forwarding_common.proto
@@ -270,7 +270,7 @@ enum CounterId {
   COUNTER_ID_MAX = 255;  // Maximum counter id.
 }
 
-// An ObjectCountesRequest is a request for counters of an object
+// An ObjectCountersRequest is a request for counters of an object
 // associated with the specified id.
 message ObjectCountersRequest {
   ObjectId object_id = 1;

--- a/proto/forwarding/forwarding_service.proto
+++ b/proto/forwarding/forwarding_service.proto
@@ -66,6 +66,7 @@ service Service {
   rpc ObjectList(ObjectListRequest) returns (ObjectListReply) {}
 
   // ObjectCounters retrieves all the counters associated on the object.
+  // TODO(wenbli): Consider adding a streaming service for counters.
   rpc ObjectCounters(ObjectCountersRequest) returns (ObjectCountersReply) {}
 
   // Operations on tables.


### PR DESCRIPTION
Currently this is done by polling the forwarding service once per second. Ideally the forwarding service supports streaming the counter values, but I think this is good enough for now. Added a TODO in the forwarding service definition.

For some reason I had to downgrade Ondatra for the traffic test to work (I think the error was target "lemming" not found) -- Could it be due to https://github.com/openconfig/ondatra/commit/3338c3259dd8419b059443cadd238841a2472015#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4 ?