### PR TITLE
Change lemming's g* services to run on different ports per intent.

### DIFF
--- a/cmd/lemming/lemming.go
+++ b/cmd/lemming/lemming.go
@@ -55,16 +55,7 @@ func main() {
 		log.Fatalf("failed to create credentials: %v", err)
 	}
 
-	gribiHost, gribiPort, err := splitHostPort(*gribiAddr)
-	if err != nil {
-		log.Exitf("cannot parse gribi listen address: %s", err)
-	}
-	gnmiHost, gnmiPort, err := splitHostPort(*gnmiAddr)
-	if err != nil {
-		log.Exitf("cannot parse gnmi listen address: %s", err)
-	}
-
-	f, err := lemming.New(*target, *zapiAddr, lemming.WithTransportCreds(creds), lemming.WithGRIBIAddr(gribiHost, gribiPort), lemming.WithGNMIAddr(gnmiHost, gnmiPort))
+	f, err := lemming.New(*target, *zapiAddr, lemming.WithTransportCreds(creds), lemming.WithGRIBIAddr(*gribiAddr), lemming.WithGNMIAddr(*gnmiAddr))
 	if err != nil {
 		log.Fatalf("Failed to start lemming: %v", err)
 	}

--- a/cmd/lemming/lemming.go
+++ b/cmd/lemming/lemming.go
@@ -22,8 +22,6 @@ import (
 	"encoding/pem"
 	"flag"
 	"math/big"
-	"net"
-	"strconv"
 
 	log "github.com/golang/glog"
 	"github.com/openconfig/lemming"
@@ -99,18 +97,4 @@ func newCreds() (credentials.TransportCredentials, error) {
 		MinVersion:   tls.VersionTLS13,
 		Certificates: []tls.Certificate{serverCert},
 	}), nil
-}
-
-func splitHostPort(address string) (string, int, error) {
-	addr, port, err := net.SplitHostPort(address)
-	if err != nil {
-		return "", 0, err
-	}
-
-	portnum, err := strconv.Atoi(port)
-	if err != nil {
-		return "", 0, err
-	}
-
-	return addr, portnum, nil
 }

--- a/lemming_test.go
+++ b/lemming_test.go
@@ -16,7 +16,6 @@ package lemming
 
 import (
 	"context"
-	"net"
 	"testing"
 
 	"github.com/h-fam/errdiff"
@@ -52,7 +51,7 @@ import (
 func TestFakeGNMI(t *testing.T) {
 	f := startLemming(t)
 	defer f.Stop()
-	conn, err := grpc.Dial(f.Addr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(f.GNMIAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to Dial fake: %v", err)
 	}
@@ -87,7 +86,7 @@ func TestFakeGNMI(t *testing.T) {
 
 func TestStop(t *testing.T) {
 	f := startLemming(t)
-	conn, err := grpc.Dial(f.Addr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(f.GNMIAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to Dial fake: %v", err)
 	}
@@ -112,7 +111,7 @@ func TestStop(t *testing.T) {
 	f.gnmiServer.GetResponses = []interface{}{want}
 	cGNMI := gnmipb.NewGNMIClient(conn)
 	// Close the listener so the get must fail.
-	f.lis.Close()
+	f.GNMIListener().Close()
 	_, err = cGNMI.Get(context.Background(), &gnmipb.GetRequest{})
 	if err == nil {
 		t.Fatalf("gnmi.Get unexpected success")
@@ -126,7 +125,7 @@ func TestStop(t *testing.T) {
 func TestFakeGNOI(t *testing.T) {
 	f := startLemming(t)
 	defer f.stop()
-	conn, err := grpc.Dial(f.Addr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(f.GNMIAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to Dial fake: %v", err)
 	}
@@ -322,11 +321,7 @@ func TestGNSI(t *testing.T) {
 */
 
 func startLemming(t *testing.T, devopts ...DevOpt) *Device {
-	lis, err := net.Listen("tcp", ":0")
-	if err != nil {
-		t.Fatalf("Failed to start listener: %v", err)
-	}
-	f, err := New(lis, "fakedevice", "unix:/tmp/zserv.api", devopts...)
+	f, err := New("fakedevice", "unix:/tmp/zserv.api", devopts...)
 	if err != nil {
 		t.Fatalf("Failed to start lemming: %v", err)
 	}

--- a/operator/config/samples/lemming_v1alpha1_lemming.yaml
+++ b/operator/config/samples/lemming_v1alpha1_lemming.yaml
@@ -9,11 +9,11 @@ spec:
   args: ["--alsologtostderr"]
   ports:
     gnmi:
-      innerPort: 6030
-      outerPort: 6030
+      innerPort: 9339
+      outerPort: 9339
     gribi:
-      innerPort: 6030
-      outerPort: 6031
+      innerPort: 9340
+      outerPort: 9340
   tls:
     selfSigned:
       commonName: "lemming-sample"


### PR DESCRIPTION
- gNMI/gNOI/gNSI on one port
- gRIBI on another
- P4RT on another

These were intended to run on different ports.

NOTE: There is actually a hack in here where I made the gRIBI service actually register in the same place as gNMI/gNOI. This is to deal with the fact that KNE doesn't have lemming registered with the right port. This can be changed after that is done.