### PR TITLE
Skip validating state SetRequest/updates.

### DIFF
--- a/dataplane/forwarding/infra/fwdpacket/packet.go
+++ b/dataplane/forwarding/infra/fwdpacket/packet.go
@@ -203,9 +203,9 @@ var logMu sync.Mutex
 func Log(packet Packet) {
 	if m := packet.Log(); len(m) != 0 {
 		logMu.Lock()
-		log.Infof("Packet Trace:\n")
+		log.V(1).Infof("Packet Trace:\n")
 		for _, msg := range m {
-			log.Infof("%v\n", msg)
+			log.V(1).Infof("%v\n", msg)
 		}
 		logMu.Unlock()
 	}

--- a/gnmi/cache.go
+++ b/gnmi/cache.go
@@ -107,7 +107,9 @@ func (c *localClient) Subscribe(ctx context.Context, _ ...grpc.CallOption) (gpb.
 
 	go func() {
 		err := c.srv.Subscribe(sub)
-		errCh <- err
+		if err != nil {
+			errCh <- err
+		}
 	}()
 	return client, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/h-fam/errdiff v1.0.2
 	github.com/kentik/patricia v1.2.0
 	github.com/open-traffic-generator/snappi/gosnappi v0.10.8
-	github.com/openconfig/gnmi v0.0.0-20220920173703-480bf53a74d2
+	github.com/openconfig/gnmi v0.9.1
 	github.com/openconfig/gnoi v0.0.0-20221111175026-79709cdf28e1
 	github.com/openconfig/gnsi v0.0.0-20221208171320-0b0fb2f32f67
 	github.com/openconfig/goyang v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,9 @@ github.com/open-traffic-generator/snappi/gosnappi v0.10.4 h1:LhcvWPBcnZK/z2ihOhp
 github.com/open-traffic-generator/snappi/gosnappi v0.10.4/go.mod h1:jscPwzdT/z64GxIKPxju4RtjkB0GIGVqnALMYvJ0fB4=
 github.com/openconfig/gnmi v0.0.0-20200414194230-1597cc0f2600/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
 github.com/openconfig/gnmi v0.0.0-20200508230933-d19cebf5e7be/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
-github.com/openconfig/gnmi v0.0.0-20220920173703-480bf53a74d2 h1:3YLlQFLDsFTvruKoYBbuYqhCgsXMtNewSrLjNXcF/Sg=
 github.com/openconfig/gnmi v0.0.0-20220920173703-480bf53a74d2/go.mod h1:Y9os75GmSkhHw2wX8sMsxfI7qRGAEcDh8NTa5a8vj6E=
+github.com/openconfig/gnmi v0.9.1 h1:hVOdLTaRjdy68oCGJbkf2vrmnUoQ5xbINqBOAMix4xM=
+github.com/openconfig/gnmi v0.9.1/go.mod h1:Y9os75GmSkhHw2wX8sMsxfI7qRGAEcDh8NTa5a8vj6E=
 github.com/openconfig/gnoi v0.0.0-20221111175026-79709cdf28e1 h1:PuoTTRGmVb642GkyUTMOlW9gc8KMDKHXLY0ie7bLPvs=
 github.com/openconfig/gnoi v0.0.0-20221111175026-79709cdf28e1/go.mod h1:ZMRwQ7maVNSOjie3Jn67fW5WY7UDrFSiYSlV/GxthQs=
 github.com/openconfig/gnsi v0.0.0-20221208171320-0b0fb2f32f67 h1:r1GtPxuMqnIyogRTJL8TmJOgxTuOQ8TZMgQFly3yF5Y=

--- a/integration_tests/twodut_oneotg_tests/bgp_redistribution_test.go
+++ b/integration_tests/twodut_oneotg_tests/bgp_redistribution_test.go
@@ -506,11 +506,11 @@ func TestBGPRouteAdvertisement(t *testing.T) {
 		},
 	})
 
-	loss := testTraffic(t, otg, atePort1, atePort2, "198.51.100.0", 15*time.Second)
+	loss := testTraffic(t, otg, atePort1, atePort2, "198.51.100.0", 3*time.Second)
 	if loss != 100 {
 		t.Errorf("Loss: got %g, want 100", loss)
 	}
-	loss = testTrafficv6(t, otg, atePort1, atePort2, "2003::", 15*time.Second)
+	loss = testTrafficv6(t, otg, atePort1, atePort2, "2003::", 3*time.Second)
 	if loss != 100 {
 		t.Errorf("Loss: got %g, want 100", loss)
 	}

--- a/sysrib/static.go
+++ b/sysrib/static.go
@@ -82,6 +82,9 @@ func (s *Server) monitorStaticRoutes(yclient *ygnmi.Client) error {
 			}
 			staticp := rootVal.GetOrCreateNetworkInstance(fakedevice.DefaultNetworkInstance).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, fakedevice.StaticRoutingProtocol)
 			for _, sroute := range staticp.Static {
+				if sroute == nil || sroute.Prefix == nil {
+					continue
+				}
 				if route := convertStaticRoute(sroute); route != nil {
 					if err := s.setRoute(fakedevice.DefaultNetworkInstance, route); err != nil {
 						log.Warningf("Failed to add static route: %v", err)


### PR DESCRIPTION
Note that replace/deletes are not affected.

This is to enable higher performance (e.g. gRIBI adding 1000 routes).

This is a temporary solution to enable gribigo to start using lemming. The long term solution is to create an UnmarshalSetRequest utility in ygot to output all the deleted/updated paths. This would enable an O(size of SetRequest) way of computing the diff, as well as reverting the SetRequest should the validation fail.