### PR TITLE
Add local BGP test

### DIFF
--- a/bgp/local_tests/session_establish_test.go
+++ b/bgp/local_tests/session_establish_test.go
@@ -1,0 +1,107 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package local_test is an integration test of lemming's BGP functionality
+// using lemmings instantiated on localhost.
+package local_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openconfig/lemming"
+	"github.com/openconfig/lemming/gnmi/fakedevice"
+	"github.com/openconfig/lemming/gnmi/oc"
+	"github.com/openconfig/lemming/gnmi/oc/ocpath"
+	"github.com/openconfig/ygnmi/ygnmi"
+	"github.com/openconfig/ygot/ygot"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials/local"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+func ygnmiClient(t *testing.T, target string, port int) *ygnmi.Client {
+	t.Helper()
+	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", port), grpc.WithTransportCredentials(local.NewCredentials()))
+	if err != nil {
+		t.Fatalf("cannot dial gNMI server, %v", err)
+	}
+	yc, err := ygnmi.NewClient(gpb.NewGNMIClient(conn), ygnmi.WithTarget(target))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	return yc
+}
+
+func bgpWithNbr(as uint32, routerID string, nbr *oc.NetworkInstance_Protocol_Bgp_Neighbor) *oc.NetworkInstance_Protocol_Bgp {
+	bgp := &oc.NetworkInstance_Protocol_Bgp{}
+	bgp.GetOrCreateGlobal().As = ygot.Uint32(as)
+	if routerID != "" {
+		bgp.Global.RouterId = ygot.String(routerID)
+	}
+	bgp.AppendNeighbor(nbr)
+	return bgp
+}
+
+func TestSessionEstablish(t *testing.T) {
+	const (
+		dut1BgpPort uint16 = 1111
+		dut2BgpPort uint16 = 1112
+		dut1AS      uint32 = 64500
+		dut2AS      uint32 = 64501
+		addr1       string = "127.0.0.1"
+		addr2       string = "127.0.0.2"
+	)
+
+	l1, err := lemming.New("dut1", "unix:/tmp/zserv-test1.api", lemming.WithTransportCreds(insecure.NewCredentials()), lemming.WithGRIBIAddr(":7340"), lemming.WithGNMIAddr(":7339"), lemming.WithBGPPort(dut1BgpPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l1.Stop()
+
+	l2, err := lemming.New("dut2", "unix:/tmp/zserv-test2.api", lemming.WithTransportCreds(insecure.NewCredentials()), lemming.WithGRIBIAddr(":8340"), lemming.WithGNMIAddr(":8339"), lemming.WithBGPPort(dut2BgpPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l2.Stop()
+
+	dut1 := ygnmiClient(t, "dut1", 7339)
+	dut2 := ygnmiClient(t, "dut2", 8339)
+
+	bgpPath := ocpath.Root().NetworkInstance(fakedevice.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+
+	// Remove any existing BGP config
+	Delete(t, dut1, bgpPath.Config())
+	Delete(t, dut2, bgpPath.Config())
+
+	// Start a new session
+	dutConf := bgpWithNbr(dut1AS, addr1, &oc.NetworkInstance_Protocol_Bgp_Neighbor{
+		PeerAs:          ygot.Uint32(dut2AS),
+		NeighborAddress: ygot.String(addr2),
+		NeighborPort:    ygot.Uint16(dut2BgpPort),
+	})
+	dut2Conf := bgpWithNbr(dut2AS, addr2, &oc.NetworkInstance_Protocol_Bgp_Neighbor{
+		PeerAs:          ygot.Uint32(dut1AS),
+		NeighborAddress: ygot.String(addr1),
+		NeighborPort:    ygot.Uint16(dut1BgpPort),
+	})
+	Replace(t, dut1, bgpPath.Config(), dutConf)
+	Replace(t, dut2, bgpPath.Config(), dut2Conf)
+
+	nbrPath := bgpPath.Neighbor(addr2)
+	Await(t, dut1, nbrPath.SessionState().State(), oc.Bgp_Neighbor_SessionState_ESTABLISHED)
+}

--- a/bgp/local_tests/ygnmi_test.go
+++ b/bgp/local_tests/ygnmi_test.go
@@ -14,6 +14,8 @@
 
 package local_test
 
+// TODO: Consider introducing an Ondatra binding for non-dataplane tests of lemming.
+
 import (
 	"context"
 	"testing"

--- a/bgp/local_tests/ygnmi_test.go
+++ b/bgp/local_tests/ygnmi_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openconfig/ygnmi/ygnmi"
+)
+
+// Update updates the configuration at the given query path with the val.
+func Update[T any](t testing.TB, c *ygnmi.Client, q ygnmi.ConfigQuery[T], val T) *ygnmi.Result {
+	t.Helper()
+	res, err := ygnmi.Update(context.Background(), c, q, val)
+	if err != nil {
+		t.Fatalf("Update(t) on %v at %v: %v", c, q, err)
+	}
+	return res
+}
+
+// Replace replaces the configuration at the given query path with the val.
+func Replace[T any](t testing.TB, c *ygnmi.Client, q ygnmi.ConfigQuery[T], val T) *ygnmi.Result {
+	t.Helper()
+	res, err := ygnmi.Replace(context.Background(), c, q, val)
+	if err != nil {
+		t.Fatalf("Replace(t) on %v at %v: %v", c, q, err)
+	}
+	return res
+}
+
+// Delete deletes the configuration at the given query path.
+func Delete[T any](t testing.TB, c *ygnmi.Client, q ygnmi.ConfigQuery[T]) *ygnmi.Result {
+	t.Helper()
+	res, err := ygnmi.Delete(context.Background(), c, q)
+	if err != nil {
+		t.Fatalf("Delete(t) on %v at %v: %v", c, q, err)
+	}
+	return res
+}
+
+// Await observes values at Query with a STREAM subscription,
+// blocking until a value that is deep equal to the specified val is received
+// or the timeout is reached. To wait for a generic predicate, or to make a
+// non-blocking call, use the Watch method instead.
+func Await[T any](t testing.TB, c *ygnmi.Client, q ygnmi.SingletonQuery[T], val T) *ygnmi.Value[T] {
+	t.Helper()
+	v, err := ygnmi.Await(context.Background(), c, q, val)
+	if err != nil {
+		t.Fatalf("Await(t) on %v at %v: %v", c, q, err)
+	}
+	return v
+}

--- a/cmd/lemming/lemming.go
+++ b/cmd/lemming/lemming.go
@@ -30,6 +30,7 @@ import (
 var (
 	gnmiAddr    = flag.String("gnmi", ":9339", "gNMI listen address")
 	gribiAddr   = flag.String("gribi", ":9340", "gRIBI listen address")
+	bgpPort     = flag.Uint("bgp_port", 179, "BGP listening port")
 	target      = pflag.String("target", "fakedut", "name of the fake target")
 	tlsKeyFile  = pflag.String("tls_key_file", "", "Controls whether to enable TLS for gNXI services. If unspecified, insecure credentials are used.")
 	tlsCertFile = pflag.String("tls_cert_file", "", "Controls whether to enable TLS for gNXI services. If unspecified, insecure credentials are used.")
@@ -52,7 +53,7 @@ func main() {
 		}
 	}
 
-	f, err := lemming.New(*target, *zapiAddr, lemming.WithTransportCreds(creds), lemming.WithGRIBIAddr(*gribiAddr), lemming.WithGNMIAddr(*gnmiAddr))
+	f, err := lemming.New(*target, *zapiAddr, lemming.WithTransportCreds(creds), lemming.WithGRIBIAddr(*gribiAddr), lemming.WithGNMIAddr(*gnmiAddr), lemming.WithBGPPort(uint16(*bgpPort)))
 	if err != nil {
 		log.Fatalf("Failed to start lemming: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.3.0
-	github.com/h-fam/errdiff v1.0.2
 	github.com/kentik/patricia v1.2.0
 	github.com/open-traffic-generator/snappi/gosnappi v0.10.11
 	github.com/openconfig/gnmi v0.9.1
@@ -20,7 +19,7 @@ require (
 	github.com/openconfig/gribigo v0.0.0-20230207233343-ef59db57c4fc
 	github.com/openconfig/kne v0.1.8-0.20230309181728-8fc46a2e57e2
 	github.com/openconfig/ondatra v0.1.7
-	github.com/openconfig/ygnmi v0.7.7
+	github.com/openconfig/ygnmi v0.7.9
 	github.com/openconfig/ygot v0.27.0
 	github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -600,7 +600,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
 github.com/h-fam/errdiff v1.0.2 h1:rPsW4ob2fMOIulwTEoZXaaUIuud7XUudw5SLKTZj3Ss=
-github.com/h-fam/errdiff v1.0.2/go.mod h1:FOzgnHXSEE3rRvmGXgmiqWl+H3lwLywYm9CSXqXrSTg=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -669,14 +668,8 @@ github.com/openconfig/gnmi v0.0.0-20200508230933-d19cebf5e7be/go.mod h1:M/EcuapN
 github.com/openconfig/gnmi v0.0.0-20220920173703-480bf53a74d2/go.mod h1:Y9os75GmSkhHw2wX8sMsxfI7qRGAEcDh8NTa5a8vj6E=
 github.com/openconfig/gnmi v0.9.1 h1:hVOdLTaRjdy68oCGJbkf2vrmnUoQ5xbINqBOAMix4xM=
 github.com/openconfig/gnmi v0.9.1/go.mod h1:Y9os75GmSkhHw2wX8sMsxfI7qRGAEcDh8NTa5a8vj6E=
-github.com/openconfig/gnoi v0.0.0-20230221223856-1727ed932554 h1:qV9anDoBeILsK/rUe7sc0DePwo7dkA45lzDQhfeTniA=
-github.com/openconfig/gnoi v0.0.0-20230221223856-1727ed932554/go.mod h1:ZMRwQ7maVNSOjie3Jn67fW5WY7UDrFSiYSlV/GxthQs=
 github.com/openconfig/gnoi v0.0.0-20230331232029-cc419f3696d3 h1:nyVpgoCaVqng9lHRFlqbdvL+z/h8dUeKmoqmdHX5WPk=
 github.com/openconfig/gnoi v0.0.0-20230331232029-cc419f3696d3/go.mod h1:ZMRwQ7maVNSOjie3Jn67fW5WY7UDrFSiYSlV/GxthQs=
-github.com/openconfig/gnsi v0.0.0-20221208171320-0b0fb2f32f67 h1:r1GtPxuMqnIyogRTJL8TmJOgxTuOQ8TZMgQFly3yF5Y=
-github.com/openconfig/gnsi v0.0.0-20221208171320-0b0fb2f32f67/go.mod h1:TxO4H2eaYh7RX5+/Vh3Q97WoM0YGTgjrmnyNWNa9kBk=
-github.com/openconfig/gnsi v0.2.0 h1:HmYKie8z1uaY9Rncanso4SPnL9RprPntPF9Lf0PBbio=
-github.com/openconfig/gnsi v0.2.0/go.mod h1:TxO4H2eaYh7RX5+/Vh3Q97WoM0YGTgjrmnyNWNa9kBk=
 github.com/openconfig/gnsi v0.2.1-0.20230406234913-6acb1b496c20 h1:oes3klKmvdxvORgGKhJMOD7Oc3bkwPnGzjAxyBezdI8=
 github.com/openconfig/gnsi v0.2.1-0.20230406234913-6acb1b496c20/go.mod h1:QikTHkm468uc2rq/kVhETfyZ6FPeM+zitubrHBbB0HE=
 github.com/openconfig/gocloser v0.0.0-20220310182203-c6c950ed3b0b h1:NSYuxdlOWLldNpid1dThR6Dci96juXioUguMho6aliI=
@@ -703,16 +696,14 @@ github.com/openconfig/ondatra v0.1.7 h1:TVUz99aoOl7Fe5u7bHlxTbV2cEHJ8iGnI+njxBGU
 github.com/openconfig/ondatra v0.1.7/go.mod h1:HysvZT04PMQ9ciYj1iw1W6a30nPwLc9LT7myYuF7tbA=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07 h1:X631iD/B0ximGFb5P9LY5wHju4SiedxUhc5UZEo7VSw=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07/go.mod h1:bmpU0kIsCiXuncozViVuQx1HqolC3C94H7lD9KKmoTo=
-github.com/openconfig/ygnmi v0.7.7 h1:VjmBhLFgPcKVftT8Uq6t3lXkCwsVTZUQmIwGIJbSfhU=
-github.com/openconfig/ygnmi v0.7.7/go.mod h1:qk5qX7+Wvg0U0VyCqEz5gPtaAPgXMxGPwPwzDv6zCXk=
+github.com/openconfig/ygnmi v0.7.9 h1:37EJcxZq6LgszCBHd4otNZkFoYzt8s4ENi9w5Ho3d9k=
+github.com/openconfig/ygnmi v0.7.9/go.mod h1:cMCgt7ptmWjxpCKcDX4QQZ0WMJcs88J0ZwPqqu1Y7NQ=
 github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=
 github.com/openconfig/ygot v0.10.4/go.mod h1:oCQNdXnv7dWc8scTDgoFkauv1wwplJn5HspHcjlxSAQ=
 github.com/openconfig/ygot v0.13.2/go.mod h1:kJN0yCXIH07dOXvNBEFm3XxXdnDD5NI6K99tnD5x49c=
 github.com/openconfig/ygot v0.25.6/go.mod h1:+IVqHe5iTfGcDRi3szuq1Mgvy5q3S4x8DG69K5kw62o=
 github.com/openconfig/ygot v0.27.0 h1:B2f6BMp4v0Lex5qzcsqODv+HdQWqcc748pQ4eDF+ty4=
 github.com/openconfig/ygot v0.27.0/go.mod h1:wlup/5e/eQM6pscY1+pJZJjLfkAPVsyLp5FJMESHcVg=
-github.com/p4lang/p4runtime v1.3.0 h1:3fUhHj0JtsGcL2Bh0uxpACdBJBDqpZyLgj93tqKzoJY=
-github.com/p4lang/p4runtime v1.3.0/go.mod h1:voPsRsgz/TDEhcaFvBxfMbI++hSKR/QGJusJveEs9Jg=
 github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e h1:AfZKoikDXbZ7zWvO/lvCRzLo7i6lM+gNleYVMxPiWyQ=
 github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e/go.mod h1:m9laObIMXM9N1ElGXijc66/MSM5eheZJLRLxg/TG+fU=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
@@ -1217,7 +1208,6 @@ google.golang.org/genproto v0.0.0-20200228133532-8c2c7df3a383/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200312145019-da6875a35672/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/genproto v0.0.0-20200413115906-b5235f65be36/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
@@ -1317,7 +1307,6 @@ google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4/go.mod h1:NWraEVix
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
-google.golang.org/grpc v1.22.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=

--- a/lemming.go
+++ b/lemming.go
@@ -77,6 +77,7 @@ type opt struct {
 	gribiAddr      string
 	gnmiAddr       string
 	p4rtAddr       string
+	bgpPort        uint16
 }
 
 // resolveOpts applies all the options and returns a struct containing the result.
@@ -117,6 +118,13 @@ func WithGNMIAddr(addr string) Option {
 func WithP4RTAddr(addr string) Option {
 	return func(o *opt) {
 		o.p4rtAddr = addr
+	}
+}
+
+// WithBGPPort is a device option that specifies that the BGP port.
+func WithBGPPort(port uint16) Option {
+	return func(o *opt) {
+		o.bgpPort = port
 	}
 }
 
@@ -180,7 +188,7 @@ func New(targetName, zapiURL string, opts ...Option) (*Device, error) {
 	recs = append(recs,
 		fakedevice.NewSystemBaseTask(),
 		fakedevice.NewBootTimeTask(),
-		bgp.NewGoBGPTaskDecl(zapiURL),
+		bgp.NewGoBGPTaskDecl(zapiURL, resolvedOpts.bgpPort),
 	)
 
 	log.Info("starting gNSI")


### PR DESCRIPTION
Just pretty much copying the integration_test's BGP session establishment test over.

* Added a ygnmi test library similar to ondatra's
* Added ability to specify local BGP listen port since OC doesn't have that knob.