### PR TITLE
Only set localAddress when routerID is loopback.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ load-debug:
 ## Run integration tests
 .PHONY: itest
 itest:
-	bazel test //integration_tests/...
+	bazel test --cache_test_results=no //integration_tests/...
 
 .PHONY: test
 test:


### PR DESCRIPTION
Otherwise the BGP thread only listens on a single port and sessions can't be established with incoming connections from other ports.

This fixes the BGP integration tests.