### PR TITLE
Ensure that lemming.Stop() returns a nil error.

### DIFF
--- a/lemming.go
+++ b/lemming.go
@@ -317,6 +317,9 @@ func (d *Device) Stop() error {
 		d.errs = append(d.errs, err)
 	}
 
+	if len(d.errs) == 0 {
+		return nil
+	}
 	return fmt.Errorf("%v", d.errs)
 }
 

--- a/lemming_test.go
+++ b/lemming_test.go
@@ -84,13 +84,22 @@ func TestFakeGNMI(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	f := startLemming(t)
-	// Close the listener so the get must fail. Sleep to ensure listener is closed before Get.
-	f.GNMIListener().Close()
-	err := f.Stop()
-	if s := errdiff.Check(err, "use of closed network connection"); s != "" {
-		t.Fatalf("failed to get error on close: %s", s)
-	}
+	t.Run("errors", func(t *testing.T) {
+		f := startLemming(t)
+		// Close the listener so the get must fail. Sleep to ensure listener is closed before Get.
+		f.GNMIListener().Close()
+		err := f.Stop()
+		if s := errdiff.Check(err, "use of closed network connection"); s != "" {
+			t.Fatalf("failed to get error on close: %s", s)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		f := startLemming(t)
+		if err := f.Stop(); err != nil {
+			t.Fatalf("did not get nil error on stop, got: %v", err)
+		}
+	})
 }
 
 func TestFakeGNOI(t *testing.T) {

--- a/lemming_test.go
+++ b/lemming_test.go
@@ -95,7 +95,7 @@ func TestStop(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		f := startLemming(t)
+		f := startLemming(t, []Option{}...)
 		if err := f.Stop(); err != nil {
 			t.Fatalf("did not get nil error on stop, got: %v", err)
 		}


### PR DESCRIPTION
```
* (M) lemming(_test)?.go
   - Today if a user does `if err := lemming.Stop(); err != nil { ... }`
     then they will report a failure even if there were no errors
     because the slice returned is non-nil.
```
