### PR TITLE
Fix <PolicyTest>/installPolicyAfterRoutes

### DIFF
--- a/bgp/gobgp.go
+++ b/bgp/gobgp.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openconfig/ygot/ygot"
 	api "github.com/wenovus/gobgp/v3/api"
 	"github.com/wenovus/gobgp/v3/pkg/bgpconfig"
+	"github.com/wenovus/gobgp/v3/pkg/packet/bgp"
 	"github.com/wenovus/gobgp/v3/pkg/server"
 	"github.com/wenovus/gobgp/v3/pkg/zebra"
 )
@@ -234,7 +235,7 @@ func (t *bgpDeclTask) startGoBGPFuncDecl(_ context.Context, yclient *ygnmi.Clien
 					Safi: api.Family_SAFI_UNICAST,
 				},
 			}, func(d *api.Destination) {
-				log.V(0).Infof("%s: GoBGP global table path: %v", t.targetName, d)
+				log.V(1).Infof("%s: GoBGP global table path: %v", t.targetName, d)
 			}); err != nil {
 				log.Errorf("GoBGP ListPath call failed (global table): %v", err)
 			} else {
@@ -400,11 +401,18 @@ func intendedToGoBGP(bgpoc *oc.NetworkInstance_Protocol_Bgp, policyoc *oc.Routin
 		applyPolicy.Config.ImportPolicyList = convertPolicyNames(neighAddr, applyPolicy.Config.ImportPolicyList)
 		applyPolicy.Config.ExportPolicyList = convertPolicyNames(neighAddr, applyPolicy.Config.ExportPolicyList)
 
+		peerType := bgpconfig.PEER_TYPE_EXTERNAL
+		if neigh.GetPeerAs() == global.GetAs() {
+			peerType = bgpconfig.PEER_TYPE_INTERNAL
+		}
+
 		// Add neighbour config.
 		bgpConfig.Neighbors = append(bgpConfig.Neighbors, bgpconfig.Neighbor{
 			Config: bgpconfig.NeighborConfig{
+				LocalAs:         global.GetAs(),
 				PeerAs:          neigh.GetPeerAs(),
 				NeighborAddress: neighAddr,
+				PeerType:        peerType,
 			},
 			// This is needed because GoBGP's configuration diffing
 			// logic may check the state value instead of the
@@ -418,7 +426,14 @@ func intendedToGoBGP(bgpoc *oc.NetworkInstance_Protocol_Bgp, policyoc *oc.Routin
 					LocalAddress: localAddress,
 					RemotePort:   neigh.GetNeighborPort(),
 				},
+				State: bgpconfig.TransportState{
+					LocalAddress: localAddress,
+				},
 			},
+			AfiSafis: []bgpconfig.AfiSafi{{
+				Config: bgpconfig.AfiSafiConfig{AfiSafiName: "ipv4-unicast", Enabled: true},
+				State:  bgpconfig.AfiSafiState{AfiSafiName: "ipv4-unicast", Family: bgp.RF_IPv4_UC},
+			}},
 			// NOTE: From reading GoBGP's source code these are not used for filtering
 			// routes (the global ApplyPolicy list is used instead) unless the neighbour
 			// is a route server client.

--- a/bgp/gobgp.go
+++ b/bgp/gobgp.go
@@ -34,7 +34,6 @@ import (
 	"github.com/openconfig/ygot/ygot"
 	api "github.com/wenovus/gobgp/v3/api"
 	"github.com/wenovus/gobgp/v3/pkg/bgpconfig"
-	"github.com/wenovus/gobgp/v3/pkg/packet/bgp"
 	"github.com/wenovus/gobgp/v3/pkg/server"
 	"github.com/wenovus/gobgp/v3/pkg/zebra"
 )
@@ -401,18 +400,11 @@ func intendedToGoBGP(bgpoc *oc.NetworkInstance_Protocol_Bgp, policyoc *oc.Routin
 		applyPolicy.Config.ImportPolicyList = convertPolicyNames(neighAddr, applyPolicy.Config.ImportPolicyList)
 		applyPolicy.Config.ExportPolicyList = convertPolicyNames(neighAddr, applyPolicy.Config.ExportPolicyList)
 
-		peerType := bgpconfig.PEER_TYPE_EXTERNAL
-		if neigh.GetPeerAs() == global.GetAs() {
-			peerType = bgpconfig.PEER_TYPE_INTERNAL
-		}
-
 		// Add neighbour config.
 		bgpConfig.Neighbors = append(bgpConfig.Neighbors, bgpconfig.Neighbor{
 			Config: bgpconfig.NeighborConfig{
-				LocalAs:         global.GetAs(),
 				PeerAs:          neigh.GetPeerAs(),
 				NeighborAddress: neighAddr,
-				PeerType:        peerType,
 			},
 			// This is needed because GoBGP's configuration diffing
 			// logic may check the state value instead of the
@@ -426,14 +418,7 @@ func intendedToGoBGP(bgpoc *oc.NetworkInstance_Protocol_Bgp, policyoc *oc.Routin
 					LocalAddress: localAddress,
 					RemotePort:   neigh.GetNeighborPort(),
 				},
-				State: bgpconfig.TransportState{
-					LocalAddress: localAddress,
-				},
 			},
-			AfiSafis: []bgpconfig.AfiSafi{{
-				Config: bgpconfig.AfiSafiConfig{AfiSafiName: "ipv4-unicast", Enabled: true},
-				State:  bgpconfig.AfiSafiState{AfiSafiName: "ipv4-unicast", Family: bgp.RF_IPv4_UC},
-			}},
 			// NOTE: From reading GoBGP's source code these are not used for filtering
 			// routes (the global ApplyPolicy list is used instead) unless the neighbour
 			// is a route server client.

--- a/bgp/tests/local_tests/session_establish_test.go
+++ b/bgp/tests/local_tests/session_establish_test.go
@@ -191,12 +191,6 @@ func awaitSessionEstablished(t *testing.T, dut1, dut2 *ygnmi.Client, spec1, spec
 	Await(t, dut2, bgp.BGPPath.Neighbor(spec1.RouterID).SessionState().State(), oc.Bgp_Neighbor_SessionState_ESTABLISHED)
 }
 
-func awaitSessionIdle(t *testing.T, dut1, dut2 *ygnmi.Client, spec1, spec2 DeviceSpec) {
-	t.Helper()
-	Await(t, dut1, bgp.BGPPath.Neighbor(spec2.RouterID).SessionState().State(), oc.Bgp_Neighbor_SessionState_IDLE)
-	Await(t, dut2, bgp.BGPPath.Neighbor(spec1.RouterID).SessionState().State(), oc.Bgp_Neighbor_SessionState_IDLE)
-}
-
 func TestSessionEstablish(t *testing.T) {
 	dut1, stop1 := newLemming(t, dut1spec, nil)
 	defer stop1()

--- a/bgp/tests/local_tests/ygnmi_test.go
+++ b/bgp/tests/local_tests/ygnmi_test.go
@@ -19,6 +19,7 @@ package local_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -108,6 +109,19 @@ func Await[T any](t testing.TB, c *ygnmi.Client, q ygnmi.SingletonQuery[T], val 
 		t.Fatalf("Await(t) on %v at %v: %v", c, q, err)
 	}
 	return v
+}
+
+// AwaitWithErr is the same as Await except an error is returned.
+//
+// Its purpose is to add a better error message.
+func AwaitWithErr[T any](c *ygnmi.Client, q ygnmi.SingletonQuery[T], val T) (*ygnmi.Value[T], error) {
+	ctx, cancel := context.WithTimeout(context.Background(), awaitTimeLimit)
+	defer cancel()
+	v, err := ygnmi.Await(ctx, c, q, val)
+	if err != nil {
+		return v, fmt.Errorf("Await(t) on %v at %v: %v", c, q, err)
+	}
+	return v, nil
 }
 
 type watchAwaiter[T any] interface {

--- a/dataplane/forwarding/util/stats/stats.go
+++ b/dataplane/forwarding/util/stats/stats.go
@@ -94,6 +94,7 @@ func (s *Stats) Update(id int, value int64) error {
 func (s *Stats) GetAll() map[int]int64 {
 	r := make(map[int]int64)
 	for id, stat := range s.statMap {
+		stat := stat
 		r[id] = atomic.LoadInt64(&stat.value)
 	}
 	return r


### PR DESCRIPTION
Need to check routes after reset.

Cannot use regular `Await` because need t.Fatal to be called in main test goroutine.