### PR TITLE
Increase Await timeout for BGP policy test

### DIFF
--- a/policytest/policytest.go
+++ b/policytest/policytest.go
@@ -42,7 +42,7 @@ const (
 	ipv4PrefixLen = 24
 	ipv6PrefixLen = 112
 
-	awaitTimeout  = 15 * time.Second
+	awaitTimeout  = 60 * time.Second
 	rejectTimeout = 20 * time.Second
 )
 


### PR DESCRIPTION
Recent failures are at BGP session establishment, which is the place of highest CPU usage.