### PR TITLE
Cache build and test separately

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -30,8 +30,9 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ github.sha }}
+          key: ${{ runner.os }}-bazel-build-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-bazel-build-
             ${{ runner.os }}-bazel-
       - name: Build Lemming
         run: bazel build //...
@@ -41,7 +42,7 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ github.sha }}
+          key: ${{ runner.os }}-bazel-build-${{ github.sha }}
   test:
     runs-on: ubuntu-latest
     steps:
@@ -53,8 +54,9 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ github.sha }}
+          key: ${{ runner.os }}-bazel-test-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-bazel-test-
             ${{ runner.os }}-bazel-
       - name: Test
         run: make coverage
@@ -71,4 +73,4 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ github.sha }}
+          key: ${{ runner.os }}-bazel-test-${{ github.sha }}


### PR DESCRIPTION
Since not all build targets have tests, the build cache is more complete than the test cache