### PR TITLE
Change BGP tests to wait for policy state

### DIFF
--- a/bgp/tests/local_tests/community_set_test.go
+++ b/bgp/tests/local_tests/community_set_test.go
@@ -68,6 +68,7 @@ func TestCommunitySet(t *testing.T) {
 		// Install policy
 		Replace(t, dut2, ocpath.Root().RoutingPolicy().PolicyDefinition(policyName).Config(), &oc.RoutingPolicy_PolicyDefinition{Statement: policy})
 		Replace(t, dut2, bgp.BGPPath.Neighbor(dut1.RouterID).ApplyPolicy().ImportPolicy().Config(), []string{policyName})
+		Await(t, dut2, bgp.BGPPath.Neighbor(dut1.RouterID).ApplyPolicy().ImportPolicy().State(), []string{policyName})
 	}
 
 	routeUnderTestList := []string{
@@ -168,6 +169,7 @@ func TestCommunitySet(t *testing.T) {
 		// Install policy
 		Replace(t, dut1, ocpath.Root().RoutingPolicy().PolicyDefinition(policyName).Config(), &oc.RoutingPolicy_PolicyDefinition{Name: ygot.String(policyName), Statement: policy})
 		Replace(t, dut1, bgp.BGPPath.Neighbor(dut2.RouterID).ApplyPolicy().ExportPolicy().Config(), []string{policyName})
+		Await(t, dut1, bgp.BGPPath.Neighbor(dut2.RouterID).ApplyPolicy().ExportPolicy().State(), []string{policyName})
 	}
 
 	test := func(testRef bool) {

--- a/bgp/tests/local_tests/prefix_set_test.go
+++ b/bgp/tests/local_tests/prefix_set_test.go
@@ -84,6 +84,7 @@ func TestPrefixSet(t *testing.T) {
 		// Install policy
 		Replace(t, dut2, ocpath.Root().RoutingPolicy().PolicyDefinition(policyName).Config(), &oc.RoutingPolicy_PolicyDefinition{Statement: policy})
 		Replace(t, dut2, bgp.BGPPath.Neighbor(dut1.RouterID).ApplyPolicy().ImportPolicy().Config(), []string{policyName})
+		Await(t, dut2, bgp.BGPPath.Neighbor(dut1.RouterID).ApplyPolicy().ImportPolicy().State(), []string{policyName})
 	}
 
 	invertResult := func(result valpb.RouteTestResult, invert bool) valpb.RouteTestResult {

--- a/bgp/tests/local_tests/route_propagation_test.go
+++ b/bgp/tests/local_tests/route_propagation_test.go
@@ -76,6 +76,16 @@ func TestRoutePropagation(t *testing.T) {
 
 	establishSessionPairs(t, []DevicePair{{dut1, dut2}, {dut2, dut3}, {dut3, dut4}}...)
 
+	awaitDefaultPolicies := func() {
+		Await(t, dut1, bgp.BGPPath.Neighbor(dut2.RouterID).ApplyPolicy().DefaultExportPolicy().State(), oc.RoutingPolicy_DefaultPolicyType_ACCEPT_ROUTE)
+		Await(t, dut2, bgp.BGPPath.Neighbor(dut1.RouterID).ApplyPolicy().DefaultImportPolicy().State(), oc.RoutingPolicy_DefaultPolicyType_ACCEPT_ROUTE)
+		Await(t, dut2, bgp.BGPPath.Neighbor(dut3.RouterID).ApplyPolicy().DefaultExportPolicy().State(), oc.RoutingPolicy_DefaultPolicyType_ACCEPT_ROUTE)
+		Await(t, dut3, bgp.BGPPath.Neighbor(dut2.RouterID).ApplyPolicy().DefaultImportPolicy().State(), oc.RoutingPolicy_DefaultPolicyType_ACCEPT_ROUTE)
+		Await(t, dut3, bgp.BGPPath.Neighbor(dut4.RouterID).ApplyPolicy().DefaultExportPolicy().State(), oc.RoutingPolicy_DefaultPolicyType_ACCEPT_ROUTE)
+		Await(t, dut4, bgp.BGPPath.Neighbor(dut3.RouterID).ApplyPolicy().DefaultImportPolicy().State(), oc.RoutingPolicy_DefaultPolicyType_ACCEPT_ROUTE)
+	}
+	awaitDefaultPolicies()
+
 	prefix := "10.10.10.0/24"
 	installStaticRoute(t, dut1, &oc.NetworkInstance_Protocol_Static{
 		Prefix: ygot.String(prefix),

--- a/bgp/tests/local_tests/set_attributes_test.go
+++ b/bgp/tests/local_tests/set_attributes_test.go
@@ -304,13 +304,17 @@ func TestSetAttributes(t *testing.T) {
 			// Install export policies
 			Replace(t, dut1, ocpath.Root().RoutingPolicy().PolicyDefinition(dut1ExportPolicyName).Config(), &oc.RoutingPolicy_PolicyDefinition{Name: ygot.String(dut1ExportPolicyName), Statement: dut1ExportPolicy})
 			Replace(t, dut1, bgp.BGPPath.Neighbor(dut2.RouterID).ApplyPolicy().ExportPolicy().Config(), []string{dut1ExportPolicyName})
+			Await(t, dut1, bgp.BGPPath.Neighbor(dut2.RouterID).ApplyPolicy().ExportPolicy().State(), []string{dut1ExportPolicyName})
 			Replace(t, dut5, ocpath.Root().RoutingPolicy().PolicyDefinition(dut5ExportPolicyName).Config(), &oc.RoutingPolicy_PolicyDefinition{Name: ygot.String(dut5ExportPolicyName), Statement: dut5ExportPolicy})
 			Replace(t, dut5, bgp.BGPPath.Neighbor(dut2.RouterID).ApplyPolicy().ExportPolicy().Config(), []string{dut5ExportPolicyName})
+			Await(t, dut5, bgp.BGPPath.Neighbor(dut2.RouterID).ApplyPolicy().ExportPolicy().State(), []string{dut5ExportPolicyName})
 			// Install import policies
 			Replace(t, dut2, ocpath.Root().RoutingPolicy().PolicyDefinition(dut1ImportPolicyName).Config(), &oc.RoutingPolicy_PolicyDefinition{Name: ygot.String(dut1ImportPolicyName), Statement: dut1ImportPolicy})
 			Replace(t, dut2, bgp.BGPPath.Neighbor(dut1.RouterID).ApplyPolicy().ImportPolicy().Config(), []string{dut1ImportPolicyName})
+			Await(t, dut2, bgp.BGPPath.Neighbor(dut1.RouterID).ApplyPolicy().ImportPolicy().State(), []string{dut1ImportPolicyName})
 			Replace(t, dut2, ocpath.Root().RoutingPolicy().PolicyDefinition(dut5ImportPolicyName).Config(), &oc.RoutingPolicy_PolicyDefinition{Name: ygot.String(dut5ImportPolicyName), Statement: dut5ImportPolicy})
 			Replace(t, dut2, bgp.BGPPath.Neighbor(dut5.RouterID).ApplyPolicy().ImportPolicy().Config(), []string{dut5ImportPolicyName})
+			Await(t, dut2, bgp.BGPPath.Neighbor(dut5.RouterID).ApplyPolicy().ImportPolicy().State(), []string{dut5ImportPolicyName})
 		},
 	})
 }


### PR DESCRIPTION
Previously it's depending on policy to be configured prior to BGP session establishment.

Don't depend on this, and instead on `Await` for the policy to be configured.