### PR TITLE
Don't require Target when doing gNMI requests

### DIFF
--- a/gnmi/BUILD
+++ b/gnmi/BUILD
@@ -27,6 +27,7 @@ go_library(
         "@org_golang_google_grpc//peer",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//encoding/prototext",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_x_exp//slices",
     ],
 )

--- a/gnmi/collector.go
+++ b/gnmi/collector.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openconfig/gnmi/cache"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/subscribe"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -125,10 +126,12 @@ func (c *Collector) GnmiUpdate(n *gpb.Notification) error {
 	t := c.cache.GetTarget(c.name)
 	// If target is not specified, then set it to the initialized
 	// value.
-	if n.Prefix == nil {
-		n.Prefix = &gpb.Path{}
-	}
-	if n.Prefix.Target == "" {
+	if n.GetPrefix().GetTarget() == "" {
+		if n.Prefix == nil {
+			n.Prefix = &gpb.Path{}
+		} else {
+			n.Prefix = proto.Clone(n.Prefix).(*gpb.Path)
+		}
 		n.Prefix.Target = c.name
 	}
 	return t.GnmiUpdate(n)

--- a/lemming.go
+++ b/lemming.go
@@ -188,6 +188,7 @@ func New(targetName, zapiURL string, opts ...Option) (*Device, error) {
 	if creds != nil {
 		grpcOpts = append(grpcOpts, grpc.Creds(creds))
 	}
+	grpcOpts = append(grpcOpts, grpc.StreamInterceptor(fgnmi.NewStreamInterceptorFn(targetName)))
 
 	s := grpc.NewServer(grpcOpts...)
 

--- a/lemming.go
+++ b/lemming.go
@@ -188,7 +188,7 @@ func New(targetName, zapiURL string, opts ...Option) (*Device, error) {
 	if creds != nil {
 		grpcOpts = append(grpcOpts, grpc.Creds(creds))
 	}
-	grpcOpts = append(grpcOpts, grpc.StreamInterceptor(fgnmi.NewStreamInterceptorFn(targetName)))
+	grpcOpts = append(grpcOpts, grpc.StreamInterceptor(fgnmi.NewSubscribeTargetUpdateInterceptor(targetName)))
 
 	s := grpc.NewServer(grpcOpts...)
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -2420,8 +2420,8 @@ def go_repositories():
     go_repository(
         name = "com_google_cloud_go_gaming",
         importpath = "cloud.google.com/go/gaming",
-        sum = "h1:5qZmZEWzMf8GEFgm9NeC3bjFRpt7x4S6U7oLbxaf7N8=",
-        version = "v1.10.1",
+        sum = "h1:7vEhFnZmd931Mo7sZ6pJy7uQPDxF7m7v8xtBheG08tc=",
+        version = "v1.9.0",
     )
     go_repository(
         name = "com_google_cloud_go_gkebackup",
@@ -2450,8 +2450,8 @@ def go_repositories():
     go_repository(
         name = "com_google_cloud_go_grafeas",
         importpath = "cloud.google.com/go/grafeas",
-        sum = "h1:oyTL/KjiUeBs9eYLw/40cpSZglUC+0F7X4iu/8t7NWs=",
-        version = "v0.3.0",
+        sum = "h1:CYjC+xzdPvbV65gi6Dr4YowKcmLo045pm18L0DhdELM=",
+        version = "v0.2.0",
     )
     go_repository(
         name = "com_google_cloud_go_gsuiteaddons",
@@ -3348,8 +3348,8 @@ def go_repositories():
     go_repository(
         name = "org_golang_x_tools",
         importpath = "golang.org/x/tools",
-        sum = "h1:8WMNJAz3zrtPmnYC7ISf5dEn3MT0gY7jBJfw27yrrLo=",
-        version = "v0.9.1",
+        sum = "h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=",
+        version = "v0.7.0",
     )
     go_repository(
         name = "org_golang_x_xerrors",


### PR DESCRIPTION
* Auto-populate Target when doing gNMI requests
* Auto-remove Target when responding to gNMI SubscribeRequest that didn't have prefix populated: https://www.openconfig.net/docs/gnmi/gnmi-specification/#2221-path-target

Resolves #263 