### PR TITLE
Support BGP Route Deletion

### DIFF
--- a/sysrib/server_zapi.go
+++ b/sysrib/server_zapi.go
@@ -84,13 +84,13 @@ func convertToZAPIRoute(routeKey RouteKey, route *Route, rr *ResolvedRoute) (*ze
 }
 
 // setZebraRoute calls setRoute after reformatting a zebra-formatted input route.
-func (s *Server) setZebraRoute(ctx context.Context, niName string, zroute *zebra.IPRouteBody) error {
+func (s *Server) setZebraRoute(ctx context.Context, niName string, zroute *zebra.IPRouteBody, isDelete bool) error {
 	if s == nil {
 		return fmt.Errorf("cannot add route to nil sysrib server")
 	}
 	log.V(1).Infof("setZebraRoute: %+v", *zroute)
 	route := convertZebraRoute(niName, zroute)
-	return s.setRoute(ctx, niName, route, false)
+	return s.setRoute(ctx, niName, route, isDelete)
 }
 
 // convertZebraRoute converts a zebra route to a Sysrib route.

--- a/sysrib/zapi.go
+++ b/sysrib/zapi.go
@@ -266,7 +266,7 @@ func (c *Client) HandleRequest(ctx context.Context, conn net.Conn, vrfID uint32)
 					"Topic":   "Sysrib",
 					"Message": m,
 				})
-			if err := c.zServer.sysrib.setZebraRoute(ctx, vrfIDToNiName(vrfID), m.Body.(*zebra.IPRouteBody)); err != nil {
+			if err := c.zServer.sysrib.setZebraRoute(ctx, vrfIDToNiName(vrfID), m.Body.(*zebra.IPRouteBody), false); err != nil {
 				topicLogger.Warn(fmt.Sprintf("Could not add route to sysrib: %v", err),
 					bgplog.Fields{
 						"Topic":   "Sysrib",
@@ -274,12 +274,18 @@ func (c *Client) HandleRequest(ctx context.Context, conn net.Conn, vrfID uint32)
 					})
 			}
 		case zebra.RouteDelete:
-			// TODO(wenbli): Implement RouteDelete.
-			topicLogger.Warn("Received Zebra RouteDelete from client which is not handled:",
+			topicLogger.Info("Received Zebra RouteDelete from client:",
 				bgplog.Fields{
 					"Topic":   "Sysrib",
 					"Message": m,
 				})
+			if err := c.zServer.sysrib.setZebraRoute(ctx, vrfIDToNiName(vrfID), m.Body.(*zebra.IPRouteBody), true); err != nil {
+				topicLogger.Warn(fmt.Sprintf("Could not delete route from sysrib: %v", err),
+					bgplog.Fields{
+						"Topic":   "Sysrib",
+						"Message": m,
+					})
+			}
 		default:
 			topicLogger.Warn(fmt.Sprintf("Received unhandled Zebra message %v from client:", command),
 				bgplog.Fields{

--- a/sysrib/zapi_test.go
+++ b/sysrib/zapi_test.go
@@ -505,7 +505,6 @@ func testRouteAddDelete(t *testing.T) {
 // client dials to the ZAPI server.
 func testRouteRedistribution(t *testing.T, routeReadyBeforeDial bool) {
 	routesQuery := programmedRoutesQuery(t)
-	// Sequential test
 	tests := []struct {
 		desc              string
 		inAddIntfAction   *AddIntfAction

--- a/sysrib/zapi_test.go
+++ b/sysrib/zapi_test.go
@@ -49,7 +49,7 @@ import (
 
 func TestZServer(t *testing.T) {
 	t.Run("hello", testHello)
-	t.Run("RouteAdd", testRouteAdd)
+	t.Run("RouteAdd", testRouteAddDelete)
 	t.Run("RouteRedistribution-routeReadyBeforeDial", func(t *testing.T) { testRouteRedistribution(t, true) })
 	t.Run("RouteRedistribution-routeNotReadyBeforeDial", func(t *testing.T) { testRouteRedistribution(t, false) })
 }
@@ -114,37 +114,335 @@ func testHello(t *testing.T) {
 	}
 }
 
-func testRouteAdd(t *testing.T) {
+func testRouteAddDelete(t *testing.T) {
+	routesQuery := programmedRoutesQuery(t)
+	// Sequential test
 	tests := []struct {
-		desc   string
-		inBody *zebra.IPRouteBody
+		desc            string
+		inBody          *zebra.IPRouteBody
+		inAddIntfAction *AddIntfAction
+		inDelete        bool
+		wantRoutes      []*dpb.Route
 	}{{
 		desc: "IPv4",
-		inBody: &zebra.IPRouteBody{Prefix: zebra.Prefix{
-			Family:    syscall.AF_INET,
-			PrefixLen: 24,
-			Prefix:    net.IPv4(10, 0, 0, 0),
+		inBody: &zebra.IPRouteBody{
+			Type: zebra.RouteBGP,
+			Prefix: zebra.Prefix{
+				Family:    syscall.AF_INET,
+				PrefixLen: 8,
+				// TODO(wenbli): This is probably a bug in GoBGP's zebra library.
+				//Prefix:    net.ParseIP("10.0.0.0"),
+				Prefix: net.ParseIP("0a0a::"),
+			},
+			Nexthops: []zebra.Nexthop{{
+				VrfID:  0,
+				Gate:   net.ParseIP("192.168.1.42"),
+				Weight: 1,
+			}},
+			Flags:   zebra.FlagAllowRecursion,
+			Safi:    zebra.SafiUnicast,
+			Message: zebra.MessageNexthop,
+		},
+		inAddIntfAction: &AddIntfAction{
+			name:    "eth0",
+			ifindex: 0,
+			enabled: true,
+			prefix:  "192.168.1.1/24",
+			niName:  "DEFAULT",
+		},
+		wantRoutes: []*dpb.Route{{
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "10.0.0.0/8",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Ip: &dpb.NextHop_IpStr{IpStr: "192.168.1.42"},
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
+		}, {
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "192.168.1.0/24",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
 		}},
 	}, {
 		desc: "IPv6",
-		inBody: &zebra.IPRouteBody{Prefix: zebra.Prefix{
-			Family:    syscall.AF_INET6,
-			PrefixLen: 49,
-			Prefix:    net.ParseIP("2001:aaaa:bbbb::"),
+		inBody: &zebra.IPRouteBody{
+			Type: zebra.RouteBGP,
+			Prefix: zebra.Prefix{
+				Family:    syscall.AF_INET6,
+				PrefixLen: 42,
+				Prefix:    net.ParseIP("4242::"),
+			},
+			Nexthops: []zebra.Nexthop{{
+				VrfID:  0,
+				Gate:   net.ParseIP("2001::ffff"),
+				Weight: 1,
+			}},
+			Flags:   zebra.FlagAllowRecursion,
+			Safi:    zebra.SafiUnicast,
+			Message: zebra.MessageNexthop,
+		},
+		inAddIntfAction: &AddIntfAction{
+			name:    "eth0",
+			ifindex: 0,
+			enabled: true,
+			prefix:  "2001::aaaa/42",
+			niName:  "DEFAULT",
+		},
+		wantRoutes: []*dpb.Route{{
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "10.0.0.0/8",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Ip: &dpb.NextHop_IpStr{IpStr: "192.168.1.42"},
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
+		}, {
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "192.168.1.0/24",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
+		}, {
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "4242::/42",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Ip: &dpb.NextHop_IpStr{IpStr: "2001::ffff"},
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
+		}, {
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "2001::/42",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
+		}},
+	}, {
+		desc: "IPv4-delete",
+		inBody: &zebra.IPRouteBody{
+			Type: zebra.RouteBGP,
+			Prefix: zebra.Prefix{
+				Family:    syscall.AF_INET,
+				PrefixLen: 8,
+				// TODO(wenbli): This is probably a bug in GoBGP's zebra library.
+				//Prefix:    net.ParseIP("10.0.0.0"),
+				Prefix: net.ParseIP("0a0a::"),
+			},
+			Nexthops: []zebra.Nexthop{{
+				VrfID:  0,
+				Gate:   net.ParseIP("192.168.1.42"),
+				Weight: 1,
+			}},
+			Flags:   zebra.FlagAllowRecursion,
+			Safi:    zebra.SafiUnicast,
+			Message: zebra.MessageNexthop,
+		},
+		inDelete: true,
+		wantRoutes: []*dpb.Route{{
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "192.168.1.0/24",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
+		}, {
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "4242::/42",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Ip: &dpb.NextHop_IpStr{IpStr: "2001::ffff"},
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
+		}, {
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "2001::/42",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
+		}},
+	}, {
+		desc: "IPv6-delete",
+		inBody: &zebra.IPRouteBody{
+			Type: zebra.RouteBGP,
+			Prefix: zebra.Prefix{
+				Family:    syscall.AF_INET6,
+				PrefixLen: 42,
+				Prefix:    net.ParseIP("4242::"),
+			},
+			Nexthops: []zebra.Nexthop{{
+				VrfID:  0,
+				Gate:   net.ParseIP("2001::ffff"),
+				Weight: 1,
+			}},
+			Flags:   zebra.FlagAllowRecursion,
+			Safi:    zebra.SafiUnicast,
+			Message: zebra.MessageNexthop,
+		},
+		inDelete: true,
+		wantRoutes: []*dpb.Route{{
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "192.168.1.0/24",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
+		}, {
+			Prefix: &dpb.RoutePrefix{
+				VrfId: uint64(0),
+				Prefix: &dpb.RoutePrefix_Cidr{
+					Cidr: "2001::/42",
+				},
+			},
+			Hop: &dpb.Route_NextHops{
+				NextHops: &dpb.NextHopList{
+					Hops: []*dpb.NextHop{{
+						Dev: &dpb.NextHop_Port{
+							Port: "eth0",
+						},
+						Weight: 0,
+					}},
+				},
+			},
 		}},
 	}}
 
+	s := ZAPIServerStart(t)
+	defer s.Stop()
+
+	conn, err := Dial()
+	if err != nil {
+		t.Errorf("Dial failed %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	grpcServer := grpc.NewServer()
+	gnmiServer, err := gnmi.New(grpcServer, "local", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := gnmiServer.LocalClient()
+	if err := s.sysrib.Start(context.Background(), client, "local", "unix:/tmp/zserv.api"); err != nil {
+		t.Fatalf("cannot start sysrib server, %v", err)
+	}
+	defer s.sysrib.Stop()
+
+	c, err := ygnmi.NewClient(client, ygnmi.WithTarget("local"))
+	if err != nil {
+		t.Fatalf("cannot create ygnmi client: %v", err)
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			s := ZAPIServerStart(t)
-			defer s.Stop()
-
-			conn, err := Dial()
-			if err != nil {
-				t.Errorf("Dial failed %v\n", err)
-				return
+			if tt.inAddIntfAction != nil {
+				configureInterface(t, tt.inAddIntfAction, c)
 			}
-			defer conn.Close()
 
 			serverVersion := zebra.MaxZapiVer
 			serverSoftware := zebra.MaxSoftware
@@ -153,6 +451,7 @@ func testRouteAdd(t *testing.T) {
 					Len:     zebra.HeaderSize(serverVersion),
 					Marker:  zebra.HeaderMarker(serverVersion),
 					Version: serverVersion,
+					VrfID:   zebra.DefaultVrf,
 					Command: zebra.Hello.ToEach(serverVersion, serverSoftware),
 				},
 				Body: &zebra.HelloBody{},
@@ -166,12 +465,33 @@ func testRouteAdd(t *testing.T) {
 					Len:     zebra.HeaderSize(serverVersion),
 					Marker:  zebra.HeaderMarker(serverVersion),
 					Version: serverVersion,
+					VrfID:   zebra.DefaultVrf,
 					Command: zebra.RouteAdd.ToEach(serverVersion, serverSoftware),
 				},
 				Body: tt.inBody,
 			}
+			if tt.inDelete {
+				msg.Header.Command = zebra.RouteDelete.ToEach(serverVersion, serverSoftware)
+			}
 			if err := SendMessage(t, conn, &msg); err != nil {
 				t.Error(err)
+			}
+
+			for i := 0; i != maxGNMIWaitQuanta; i++ {
+				var routes []*dpb.Route
+				if routes, err = ygnmi.GetAll(context.Background(), c, routesQuery); err == nil {
+					if diff := cmp.Diff(tt.wantRoutes, routes, protocmp.Transform(), protocmp.SortRepeatedFields(new(dpb.NextHopList), "hops"), cmpopts.SortSlices(func(a, b *dpb.Route) bool {
+						return a.GetPrefix().GetCidr() < b.GetPrefix().GetCidr()
+					})); diff != "" {
+						err = fmt.Errorf("routes not equal to wantRoutes (-want, +got):\n%s", diff)
+					} else {
+						break
+					}
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+			if err != nil {
+				t.Fatalf("Routes not resolved in time limit: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
* RedistributeDel non-connected routes from RIB to ZAPI clients.
* Delete routes from RIB when ZAPI RouteDelete message is received.