### PR TITLE
Remove unnecessary calls to gosnappi SetChoice

### DIFF
--- a/integration_tests/onedut_oneotg_tests/aggregate/aggregate_test.go
+++ b/integration_tests/onedut_oneotg_tests/aggregate/aggregate_test.go
@@ -239,7 +239,7 @@ func (tc *testCase) configureATE(t *testing.T) {
 	tc.top.Ports().Add().SetName(p0.ID())
 	srcDev := tc.top.Devices().Add().SetName(ateSrc.Name)
 	srcEth := srcDev.Ethernets().Add().SetName(ateSrc.Name + ".Eth").SetMac(ateSrc.MAC)
-	srcEth.Connection().SetChoice(gosnappi.EthernetConnectionChoice.PORT_NAME).SetPortName(p0.ID())
+	srcEth.Connection().SetPortName(p0.ID())
 	srcEth.Ipv4Addresses().Add().SetName(ateSrc.Name + ".IPv4").SetAddress(ateSrc.IPv4).SetGateway(dutSrc.IPv4).SetPrefix(uint32(ateSrc.IPv4Len))
 	srcEth.Ipv6Addresses().Add().SetName(ateSrc.Name + ".IPv6").SetAddress(ateSrc.IPv6).SetGateway(dutSrc.IPv6).SetPrefix(uint32(ateSrc.IPv6Len))
 
@@ -247,7 +247,7 @@ func (tc *testCase) configureATE(t *testing.T) {
 	agg := tc.top.Lags().Add().SetName(ateDst.Name)
 	if tc.lagType == lagTypeSTATIC {
 		lagId, _ := strconv.Atoi(tc.aggID)
-		agg.Protocol().SetChoice("static").Static().SetLagId(uint32(lagId))
+		agg.Protocol().Static().SetLagId(uint32(lagId))
 		for i, p := range tc.atePorts[1:] {
 			port := tc.top.Ports().Add().SetName(p.ID())
 			newMac, err := incrementMAC(ateDst.MAC, i+1)
@@ -257,7 +257,6 @@ func (tc *testCase) configureATE(t *testing.T) {
 			agg.Ports().Add().SetPortName(port.Name()).Ethernet().SetMac(newMac).SetName("LAGRx-" + strconv.Itoa(i))
 		}
 	} else {
-		agg.Protocol().SetChoice("lacp")
 		agg.Protocol().Lacp().SetActorKey(1).SetActorSystemPriority(1).SetActorSystemId(ateDst.MAC)
 		for i, p := range tc.atePorts[1:] {
 			port := tc.top.Ports().Add().SetName(p.ID())
@@ -288,7 +287,7 @@ func (tc *testCase) configureATE(t *testing.T) {
 
 	dstDev := tc.top.Devices().Add().SetName(agg.Name() + ".dev")
 	dstEth := dstDev.Ethernets().Add().SetName(ateDst.Name + ".Eth").SetMac(ateDst.MAC)
-	dstEth.Connection().SetChoice(gosnappi.EthernetConnectionChoice.LAG_NAME).SetLagName(agg.Name())
+	dstEth.Connection().SetLagName(agg.Name())
 	dstEth.Ipv4Addresses().Add().SetName(ateDst.Name + ".IPv4").SetAddress(ateDst.IPv4).SetGateway(dutDst.IPv4).SetPrefix(uint32(ateDst.IPv4Len))
 	dstEth.Ipv6Addresses().Add().SetName(ateDst.Name + ".IPv6").SetAddress(ateDst.IPv6).SetGateway(dutDst.IPv6).SetPrefix(uint32(ateDst.IPv6Len))
 

--- a/integration_tests/onedut_oneotg_tests/bgp_route_propagation/bgp_route_propagation_test.go
+++ b/integration_tests/onedut_oneotg_tests/bgp_route_propagation/bgp_route_propagation_test.go
@@ -128,7 +128,7 @@ func (ad *ateData) ConfigureOTG(t *testing.T, otg *otg.OTG, ateList []string) go
 		ateIndex++
 
 		eth := dev.Ethernets().Add().SetName(devName + ".Eth").SetMac(v.iface.mac)
-		eth.Connection().SetChoice(gosnappi.EthernetConnectionChoice.PORT_NAME).SetPortName(port.Name())
+		eth.Connection().SetPortName(port.Name())
 		bgp := dev.Bgp().SetRouterId(v.iface.routerId)
 		if v.ip.v4 != "" {
 			address := strings.Split(v.ip.v4, "/")[0]

--- a/integration_tests/onedut_oneotg_tests/static_route_test/static_route_traffic_test.go
+++ b/integration_tests/onedut_oneotg_tests/static_route_test/static_route_traffic_test.go
@@ -163,7 +163,7 @@ func testTraffic(t *testing.T, otg *otg.OTG, srcEndPoint, dstEndPoint attrs.Attr
 	flowipv4.TxRx().Device().
 		SetTxNames([]string{srcEndPoint.Name + ".IPv4"}).
 		SetRxNames([]string{dstEndPoint.Name + ".IPv4"})
-	flowipv4.Duration().SetChoice("continuous")
+	flowipv4.Duration().Continuous()
 	flowipv4.Packet().Add().Ethernet()
 	v4 := flowipv4.Packet().Add().Ipv4()
 	v4.Src().SetValue(srcEndPoint.IPv4)
@@ -195,7 +195,7 @@ func testTrafficv6(t *testing.T, otg *otg.OTG, srcEndPoint, dstEndPoint attrs.At
 	flowipv6.TxRx().Device().
 		SetTxNames([]string{srcEndPoint.Name + ".IPv6"}).
 		SetRxNames([]string{dstEndPoint.Name + ".IPv6"})
-	flowipv6.Duration().SetChoice("continuous")
+	flowipv6.Duration().Continuous()
 	flowipv6.Packet().Add().Ethernet()
 	v6 := flowipv6.Packet().Add().Ipv6()
 	v6.Src().SetValue(srcEndPoint.IPv6)

--- a/integration_tests/onedut_oneotg_tests/traffic_test/traffic_test.go
+++ b/integration_tests/onedut_oneotg_tests/traffic_test/traffic_test.go
@@ -145,7 +145,7 @@ func testTraffic(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config, srcE
 	flowipv4.TxRx().Device().
 		SetTxNames([]string{srcEndPoint.Name + ".IPv4"}).
 		SetRxNames([]string{dstEndPoint.Name + ".IPv4"})
-	flowipv4.Duration().SetChoice("continuous")
+	flowipv4.Duration().Continuous()
 	flowipv4.Packet().Add().Ethernet()
 	v4 := flowipv4.Packet().Add().Ipv4()
 	v4.Src().SetValue(srcEndPoint.IPv4)

--- a/integration_tests/twodut_oneotg_tests/bgp_redistribution/bgp_redistribution_test.go
+++ b/integration_tests/twodut_oneotg_tests/bgp_redistribution/bgp_redistribution_test.go
@@ -238,7 +238,7 @@ func testTraffic(t *testing.T, otg *otg.OTG, srcEndPoint, dstEndPoint attrs.Attr
 	flowipv4.TxRx().Device().
 		SetTxNames([]string{srcEndPoint.Name + ".IPv4"}).
 		SetRxNames([]string{dstEndPoint.Name + ".IPv4"})
-	flowipv4.Duration().SetChoice("continuous")
+	flowipv4.Duration().Continuous()
 	flowipv4.Packet().Add().Ethernet()
 	v4 := flowipv4.Packet().Add().Ipv4()
 	v4.Src().SetValue(srcEndPoint.IPv4)
@@ -270,7 +270,7 @@ func testTrafficv6(t *testing.T, otg *otg.OTG, srcEndPoint, dstEndPoint attrs.At
 	flowipv6.TxRx().Device().
 		SetTxNames([]string{srcEndPoint.Name + ".IPv6"}).
 		SetRxNames([]string{dstEndPoint.Name + ".IPv6"})
-	flowipv6.Duration().SetChoice("continuous")
+	flowipv6.Duration().Continuous()
 	flowipv6.Packet().Add().Ethernet()
 	v6 := flowipv6.Packet().Add().Ipv6()
 	v6.Src().SetValue(srcEndPoint.IPv6)

--- a/integration_tests/twodut_oneotg_tests/bgp_triggered_gue/bgp_triggered_gue_test.go
+++ b/integration_tests/twodut_oneotg_tests/bgp_triggered_gue/bgp_triggered_gue_test.go
@@ -360,7 +360,7 @@ func testTraffic(t *testing.T, otg *otg.OTG, srcEndPoint, dstEndPoint attrs.Attr
 	flowipv4.TxRx().Device().
 		SetTxNames([]string{srcEndPoint.Name + ".IPv4"}).
 		SetRxNames([]string{dstEndPoint.Name + ".IPv4"})
-	flowipv4.Duration().SetChoice("continuous")
+	flowipv4.Duration().Continuous()
 	flowipv4.Packet().Add().Ethernet()
 	v4 := flowipv4.Packet().Add().Ipv4()
 	v4.Src().SetValue(srcEndPoint.IPv4)
@@ -392,7 +392,7 @@ func testTrafficv6(t *testing.T, otg *otg.OTG, srcEndPoint, dstEndPoint attrs.At
 	flowipv6.TxRx().Device().
 		SetTxNames([]string{srcEndPoint.Name + ".IPv6"}).
 		SetRxNames([]string{dstEndPoint.Name + ".IPv6"})
-	flowipv6.Duration().SetChoice("continuous")
+	flowipv6.Duration().Continuous()
 	flowipv6.Packet().Add().Ethernet()
 	v6 := flowipv6.Packet().Add().Ipv6()
 	v6.Src().SetValue(srcEndPoint.IPv6)

--- a/internal/attrs/attrs.go
+++ b/internal/attrs/attrs.go
@@ -23,10 +23,9 @@ import (
 	"fmt"
 
 	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/openconfig/lemming/gnmi/oc"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ygot/ygot"
-
-	"github.com/openconfig/lemming/gnmi/oc"
 )
 
 // Attributes bundles some common attributes for devices and/or interfaces.

--- a/internal/attrs/attrs.go
+++ b/internal/attrs/attrs.go
@@ -23,9 +23,10 @@ import (
 	"fmt"
 
 	"github.com/open-traffic-generator/snappi/gosnappi"
-	"github.com/openconfig/lemming/gnmi/oc"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ygot/ygot"
+
+	"github.com/openconfig/lemming/gnmi/oc"
 )
 
 // Attributes bundles some common attributes for devices and/or interfaces.
@@ -106,7 +107,7 @@ func (a *Attributes) AddToOTG(top gosnappi.Config, ap *ondatra.Port, peer *Attri
 	top.Ports().Add().SetName(ap.ID())
 	dev := top.Devices().Add().SetName(a.Name)
 	eth := dev.Ethernets().Add().SetName(a.Name + ".Eth").SetMac(a.MAC)
-	eth.Connection().SetChoice(gosnappi.EthernetConnectionChoice.PORT_NAME).SetPortName(ap.ID())
+	eth.Connection().SetPortName(ap.ID())
 
 	if a.MTU > 0 {
 		eth.SetMtu(uint32(a.MTU))


### PR DESCRIPTION
This prepares lemming for the latest version of gosnappi, in which the SetChoice methods are removed.