### PR TITLE
Avoid redistributing BGP routes back to BGP speaker in a loop.

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package debug contains flag for turning on or off debug messages.
+// Package debug contains flags for turning on or off debug messages.
 package debug
 
 const (
@@ -22,4 +22,6 @@ const (
 	// TAPPortPacketTrace turns on packet tracing for lemming's TAP interface ports
 	// that communicate between each external port and lemming's tasks.
 	TAPPortPacketTrace = true
+	// SysRIB controls whether debug messages for the main system RIB are printed.
+	SysRIB = false
 )

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -15,6 +15,7 @@
 // Package debug contains flags for turning on or off debug messages.
 package debug
 
+// TODO: Move these flags to viper so that they're accessible via CLI.
 const (
 	// ExternalPortPacketTrace turns on packet tracing for lemming's ports
 	// that interface with other devices.

--- a/sysrib/BUILD
+++ b/sysrib/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//gnmi/gnmiclient",
         "//gnmi/oc",
         "//gnmi/oc/ocpath",
+        "//internal/debug",
         "//proto/dataplane",
         "//proto/sysrib",
         "@com_github_golang_glog//:glog",

--- a/sysrib/server.go
+++ b/sysrib/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/openconfig/lemming/gnmi/fakedevice"
 	"github.com/openconfig/lemming/gnmi/oc"
 	"github.com/openconfig/lemming/gnmi/oc/ocpath"
+	"github.com/openconfig/lemming/internal/debug"
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 
@@ -458,7 +459,7 @@ func resolvedRouteToRouteRequest(r *ResolvedRoute) (*dpb.Route, error) {
 // programs the forwarding plane.
 func (s *Server) ResolveAndProgramDiff(ctx context.Context) error {
 	log.Info("Recalculating resolved RIB")
-	if debugRIB {
+	if debug.SysRIB {
 		defer s.rib.PrintRIB()
 	}
 	s.rib.mu.RLock()
@@ -493,7 +494,7 @@ func (s *Server) ResolveAndProgramDiff(ctx context.Context) error {
 			distributeRoute(s.zServer, rr, s.resolvedRoutes[routeKey], true)
 		}
 	}
-	if debugRIB {
+	if debug.SysRIB {
 		s.PrintProgrammedRoutes()
 	}
 
@@ -551,7 +552,7 @@ func (s *Server) resolveAndProgramDiffAux(ctx context.Context, niName string, ni
 		s.programmedRoutesMu.Lock()
 		s.programmedRoutes[rr.RouteKey] = rr
 		s.programmedRoutesMu.Unlock()
-		if debugRIB {
+		if debug.SysRIB {
 			s.PrintProgrammedRoutes()
 		}
 		// ZAPI: If a new/updated route is programmed, redistribute it to clients.

--- a/sysrib/server_zapi.go
+++ b/sysrib/server_zapi.go
@@ -29,6 +29,10 @@ func distributeRoute(s *ZServer, rr *ResolvedRoute, route *Route, isDelete bool)
 	if isDelete {
 		msgType = zebra.RedistributeRouteDel
 	}
+	if route.RoutePref.AdminDistance == AdminDistanceBGP {
+		// Do not redistribute BGP routes back to the BGP speaker.
+		return
+	}
 	zrouteBody, err := convertToZAPIRoute(rr.RouteKey, route, rr)
 	if err != nil {
 		log.Warningf("failed to convert resolved route to zebra BGP route: %v", err)

--- a/sysrib/util.go
+++ b/sysrib/util.go
@@ -5,11 +5,6 @@ import (
 	"net/netip"
 )
 
-const (
-	// debugRIB controls whether debug messages for the RIB are printed.
-	debugRIB = false
-)
-
 func canonicalPrefix(prefix string) (netip.Prefix, error) {
 	pfx, err := netip.ParsePrefix(prefix)
 	if err != nil {
@@ -38,6 +33,7 @@ func (s *SysRIB) PrintRIB() {
 			}
 			fmt.Println("------------------")
 		}
+		fmt.Printf("================== END network-instance: %q ==================\n", niName)
 	}
 }
 

--- a/sysrib/zapi.go
+++ b/sysrib/zapi.go
@@ -187,6 +187,10 @@ func (c *Client) RedistributeResolvedRoutes(conn net.Conn) {
 		if !ok {
 			continue
 		}
+		if rr.RoutePref.AdminDistance == AdminDistanceBGP {
+			// Do not redistribute BGP routes back to the BGP speaker.
+			continue
+		}
 		zrouteBody, err := convertToZAPIRoute(routeKey, rr, route)
 		if err != nil {
 			topicLogger.Warn(fmt.Sprintf("failed to convert resolved route to zebra BGP route: %v", err),


### PR DESCRIPTION
BGP routes distributed from GoBGP -> sysRIB must not be redistributed back into GoBGP. Otherwise GoBGP thinks it's a locally-originated route and will prefer it over all other routes, and any BGP path attributes are also erased in the process.

BGP-triggered GUE had to be tweaked because OTG tears down the BGP session on PushConfig, so every instance of the traffic test has to wait for the BGP session to re-establish first. This issue was masked by the above bug in sysRIB.