### PR TITLE
Support Minimum gNOI Reboot and CancelReboot Functionality

### DIFF
--- a/gnmi/fakedevice/BUILD
+++ b/gnmi/fakedevice/BUILD
@@ -13,5 +13,6 @@ go_library(
         "//gnmi/reconciler",
         "@com_github_golang_glog//:glog",
         "@com_github_openconfig_ygnmi//ygnmi",
+        "@com_github_openconfig_ygot//ygot",
     ],
 )

--- a/gnoi/BUILD
+++ b/gnoi/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "gnoi",
@@ -21,6 +21,22 @@ go_library(
         "@com_github_openconfig_gnoi//otdr",
         "@com_github_openconfig_gnoi//system",
         "@com_github_openconfig_gnoi//wavelength_router",
+        "@com_github_openconfig_ygnmi//ygnmi",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+go_test(
+    name = "gnoi_test",
+    srcs = ["gnoi_test.go"],
+    embed = [":gnoi"],
+    deps = [
+        "//gnmi",
+        "//gnmi/fakedevice",
+        "//gnmi/oc/ocpath",
+        "@com_github_openconfig_gnoi//system",
         "@com_github_openconfig_ygnmi//ygnmi",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",

--- a/gnoi/BUILD
+++ b/gnoi/BUILD
@@ -6,6 +6,9 @@ go_library(
     importpath = "github.com/openconfig/lemming/gnoi",
     visibility = ["//visibility:public"],
     deps = [
+        "//gnmi/fakedevice",
+        "@com_github_golang_glog//:glog",
+        "@com_github_openconfig_gnmi//proto/gnmi",
         "@com_github_openconfig_gnoi//bgp",
         "@com_github_openconfig_gnoi//cert",
         "@com_github_openconfig_gnoi//diag",
@@ -18,6 +21,9 @@ go_library(
         "@com_github_openconfig_gnoi//otdr",
         "@com_github_openconfig_gnoi//system",
         "@com_github_openconfig_gnoi//wavelength_router",
+        "@com_github_openconfig_ygnmi//ygnmi",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/gnoi/gnoi.go
+++ b/gnoi/gnoi.go
@@ -16,8 +16,11 @@ package gnoi
 
 import (
 	"context"
+	"sync"
 	"time"
 
+	log "github.com/golang/glog"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	bpb "github.com/openconfig/gnoi/bgp"
 	cmpb "github.com/openconfig/gnoi/cert"
 	diagpb "github.com/openconfig/gnoi/diag"
@@ -30,7 +33,11 @@ import (
 	otpb "github.com/openconfig/gnoi/otdr"
 	spb "github.com/openconfig/gnoi/system"
 	wrpb "github.com/openconfig/gnoi/wavelength_router"
+	"github.com/openconfig/lemming/gnmi/fakedevice"
+	"github.com/openconfig/ygnmi/ygnmi"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type bgp struct {
@@ -75,10 +82,94 @@ type otdr struct {
 
 type system struct {
 	spb.UnimplementedSystemServer
+
+	c *ygnmi.Client
+
+	rebootMu           sync.Mutex
+	hasPendingReboot   bool
+	cancelReboot       chan struct{}
+	cancelRebootFinish chan struct{}
+}
+
+func newSystem(c *ygnmi.Client) *system {
+	return &system{
+		c:                  c,
+		cancelReboot:       make(chan struct{}, 1),
+		cancelRebootFinish: make(chan struct{}),
+	}
 }
 
 func (*system) Time(context.Context, *spb.TimeRequest) (*spb.TimeResponse, error) {
 	return &spb.TimeResponse{Time: uint64(time.Now().UnixNano())}, nil
+}
+
+func (s *system) Reboot(ctx context.Context, r *spb.RebootRequest) (*spb.RebootResponse, error) {
+	if r.Method == spb.RebootMethod_POWERUP {
+		return &spb.RebootResponse{}, nil
+	}
+
+	s.rebootMu.Lock()
+	defer s.rebootMu.Unlock()
+	if s.hasPendingReboot {
+		return nil, status.Errorf(codes.AlreadyExists, "reboot already pending")
+	}
+
+	delay := r.GetDelay()
+	if delay == 0 {
+		now := time.Now().UnixNano()
+		if err := fakedevice.Reboot(ctx, s.c, now); err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		return &spb.RebootResponse{}, nil
+	}
+
+	s.hasPendingReboot = true
+	go func() { // wait the delay time for reboot
+		select {
+		case <-s.cancelReboot:
+			log.Infof("delayed reboot cancelled")
+			s.rebootMu.Lock()
+			defer s.rebootMu.Unlock()
+			s.hasPendingReboot = false
+			s.cancelRebootFinish <- struct{}{}
+		case <-time.After(time.Duration(delay) * time.Nanosecond):
+			now := time.Now().UnixNano()
+			if err := fakedevice.Reboot(ctx, s.c, now); err != nil {
+				log.Errorf("delayed reboot failed: %v", err)
+			}
+			s.rebootMu.Lock()
+			defer s.rebootMu.Unlock()
+			s.hasPendingReboot = false
+		}
+	}()
+
+	return &spb.RebootResponse{}, nil
+}
+
+func (s *system) CancelReboot(context.Context, *spb.CancelRebootRequest) (*spb.CancelRebootResponse, error) {
+	s.rebootMu.Lock()
+	hasPendingReboot := s.hasPendingReboot
+	s.rebootMu.Unlock()
+	if !hasPendingReboot {
+		return &spb.CancelRebootResponse{}, nil
+	}
+
+	s.cancelReboot <- struct{}{} // signal cancellation
+	for {
+		select {
+		case <-s.cancelRebootFinish:
+			return &spb.CancelRebootResponse{}, nil
+		case <-time.After(time.Second):
+			s.rebootMu.Lock()
+			if !s.hasPendingReboot {
+				s.cancelRebootFinish <- struct{}{}
+				<-s.cancelReboot // drain cancellation signal that's not needed due to race condition with hasPendingReboot.
+				s.rebootMu.Unlock()
+				return &spb.CancelRebootResponse{}, nil
+			}
+			s.rebootMu.Unlock()
+		}
+	}
 }
 
 type wavelengthRouter struct {
@@ -101,7 +192,12 @@ type Server struct {
 	wavelengthRouterServer *wavelengthRouter
 }
 
-func New(s *grpc.Server) *Server {
+func New(s *grpc.Server, gClient gpb.GNMIClient, target string) (*Server, error) {
+	yclient, err := ygnmi.NewClient(gClient, ygnmi.WithTarget(target), ygnmi.WithRequestLogLevel(2))
+	if err != nil {
+		return nil, err
+	}
+
 	srv := &Server{
 		s:                      s,
 		bgpServer:              &bgp{},
@@ -114,7 +210,7 @@ func New(s *grpc.Server) *Server {
 		mplsServer:             &mpls{},
 		osServer:               &os{},
 		otdrServer:             &otdr{},
-		systemServer:           &system{},
+		systemServer:           newSystem(yclient),
 		wavelengthRouterServer: &wavelengthRouter{},
 	}
 	bpb.RegisterBGPServer(s, srv.bgpServer)
@@ -129,5 +225,5 @@ func New(s *grpc.Server) *Server {
 	otpb.RegisterOTDRServer(s, srv.otdrServer)
 	spb.RegisterSystemServer(s, srv.systemServer)
 	wrpb.RegisterWavelengthRouterServer(s, srv.wavelengthRouterServer)
-	return srv
+	return srv, nil
 }

--- a/gnoi/gnoi.go
+++ b/gnoi/gnoi.go
@@ -85,8 +85,16 @@ type system struct {
 
 	c *ygnmi.Client
 
-	rebootMu           sync.Mutex
-	hasPendingReboot   bool
+	// rebootMu has the following roles:
+	// * ensures that writes to hasPendingReboot are free from race
+	//   conditions
+	// * ensures consistency between reboot operations and the current
+	//   state of hasPendingReboot (i.e. prevent TOCCTOU race conditions).
+	rebootMu         sync.Mutex
+	hasPendingReboot bool
+	// These channels ensure that cancellation is a blocking operation to
+	// avoid future reboots from conflicting with cancelled pending
+	// reboots.
 	cancelReboot       chan struct{}
 	cancelRebootFinish chan struct{}
 }

--- a/gnoi/gnoi_test.go
+++ b/gnoi/gnoi_test.go
@@ -142,7 +142,7 @@ func TestReboot(t *testing.T) {
 
 	closeProximityTests := []struct {
 		desc  string
-		delay uint64
+		delay time.Duration
 	}{{
 		desc:  "cancel-while-possibly-pending-1ns",
 		delay: 1e0,
@@ -174,7 +174,7 @@ func TestReboot(t *testing.T) {
 
 	for _, tt := range closeProximityTests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if _, err := s.Reboot(ctx, &spb.RebootRequest{Delay: tt.delay}); err != nil {
+			if _, err := s.Reboot(ctx, &spb.RebootRequest{Delay: uint64(tt.delay.Nanoseconds())}); err != nil {
 				t.Fatal(err)
 			}
 			if _, err := s.CancelReboot(ctx, &spb.CancelRebootRequest{}); err != nil {

--- a/gnoi/gnoi_test.go
+++ b/gnoi/gnoi_test.go
@@ -1,0 +1,132 @@
+package gnoi
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	spb "github.com/openconfig/gnoi/system"
+	"github.com/openconfig/lemming/gnmi"
+	"github.com/openconfig/lemming/gnmi/fakedevice"
+	"github.com/openconfig/lemming/gnmi/oc/ocpath"
+	"github.com/openconfig/ygnmi/ygnmi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestReboot(t *testing.T) {
+	grpcServer := grpc.NewServer()
+	gnmiServer, err := gnmi.New(grpcServer, "local", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Failed to start listener: %v", err)
+	}
+	go func() {
+		grpcServer.Serve(lis)
+	}()
+
+	// Update the interface configuration on the gNMI server.
+	client := gnmiServer.LocalClient()
+
+	c, err := ygnmi.NewClient(client, ygnmi.WithTarget("local"))
+	if err != nil {
+		t.Fatalf("cannot create ygnmi client: %v", err)
+	}
+
+	s := newSystem(c)
+
+	ctx := context.Background()
+	fakedevice.NewBootTimeTask().Start(ctx, client, "local")
+
+	t.Run("zero-delay", func(t *testing.T) {
+		prevTime, err := ygnmi.Get(context.Background(), c, ocpath.Root().System().BootTime().State())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.Reboot(ctx, &spb.RebootRequest{}); err != nil {
+			t.Fatal(err)
+		}
+		afterTime, err := ygnmi.Get(context.Background(), c, ocpath.Root().System().BootTime().State())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !(prevTime < afterTime) {
+			t.Errorf("boot time did not update after reboot")
+		}
+	})
+
+	t.Run("one-second-delay", func(t *testing.T) {
+		prevTime, err := ygnmi.Get(context.Background(), c, ocpath.Root().System().BootTime().State())
+		if err != nil {
+			t.Fatal(err)
+		}
+		const delay = 1e9
+		if _, err := s.Reboot(ctx, &spb.RebootRequest{Delay: delay}); err != nil {
+			t.Fatal(err)
+		}
+
+		var afterTime uint64
+		tryN := 50
+		for i := 0; i != tryN; i++ {
+			var err error
+			afterTime, err = ygnmi.Get(context.Background(), c, ocpath.Root().System().BootTime().State())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if prevTime < afterTime {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		if !(prevTime < afterTime) {
+			t.Errorf("boot time did not update after reboot")
+		}
+
+	})
+
+	t.Run("cancel-no-pending", func(t *testing.T) {
+		if _, err := s.CancelReboot(ctx, &spb.CancelRebootRequest{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("cancel-pending", func(t *testing.T) {
+		prevTime, err := ygnmi.Get(context.Background(), c, ocpath.Root().System().BootTime().State())
+		if err != nil {
+			t.Fatal(err)
+		}
+		const delay = 120e9
+		if _, err := s.Reboot(ctx, &spb.RebootRequest{Delay: delay}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.CancelReboot(ctx, &spb.CancelRebootRequest{}); err != nil {
+			t.Fatal(err)
+		}
+
+		afterTime, err := ygnmi.Get(context.Background(), c, ocpath.Root().System().BootTime().State())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if prevTime != afterTime {
+			t.Errorf("boot did not get cancelled")
+		}
+	})
+
+	t.Run("reboot-while-pending", func(t *testing.T) {
+		const delay = 120e9
+		if _, err := s.Reboot(ctx, &spb.RebootRequest{Delay: delay}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.Reboot(ctx, &spb.RebootRequest{}); status.Convert(err).Code() != codes.AlreadyExists {
+			t.Fatalf("Expected AlreadyExists error, got %v", err)
+		}
+		if _, err := s.CancelReboot(ctx, &spb.CancelRebootRequest{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/openconfig/kne v0.1.16
 	github.com/openconfig/magna v0.0.0-20240326180454-518e16696c84
 	github.com/openconfig/ondatra v0.5.2
+	github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07
 	github.com/openconfig/ygnmi v0.11.1
 	github.com/openconfig/ygot v0.29.18
 	github.com/osrg/gobgp/v3 v3.25.1-0.20240410224816-7ef2f0bb8283

--- a/integration_tests/onedut_tests/complete_chassis_reboot/BUILD
+++ b/integration_tests/onedut_tests/complete_chassis_reboot/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "complete_chassis_reboot_test",
+    size = "enormous",
+    srcs = ["complete_chassis_reboot_test.go"],
+    data = ["//integration_tests/onedut_tests:topology_testbed"],
+    deps = [
+        "//internal/binding",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_openconfig_gnoi//system",
+        "@com_github_openconfig_ondatra//:ondatra",
+        "@com_github_openconfig_ondatra//gnmi",
+        "@com_github_openconfig_ondatra//gnmi/oc",
+        "@com_github_openconfig_testt//:testt",
+    ],
+)

--- a/integration_tests/onedut_tests/complete_chassis_reboot/complete_chassis_reboot_test.go
+++ b/integration_tests/onedut_tests/complete_chassis_reboot/complete_chassis_reboot_test.go
@@ -1,0 +1,241 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package complete_chassis_reboot_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	spb "github.com/openconfig/gnoi/system"
+	"github.com/openconfig/lemming/internal/binding"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/testt"
+)
+
+const (
+	oneMinuteInNanoSecond = 6e10
+	oneSecondInNanoSecond = 1e9
+	rebootDelay           = 120
+	// Maximum reboot time is 900 seconds (15 minutes).
+	maxRebootTime = 900
+	// Maximum wait time for all components to be in responsive state
+	maxCompWaitTime = 600
+)
+
+func TestMain(m *testing.M) {
+	ondatra.RunTests(m, binding.KNE(".."))
+}
+
+// Test cases:
+//  1) Send gNOI reboot request using the method COLD with the delay of N seconds.
+//     - method: Only the COLD method is required to be supported by all targets.
+//     - Delay: In nanoseconds before issuing reboot.
+//     - message: Informational reason for the reboot.
+//     - force: Force reboot if basic checks fail. (ex. uncommitted configuration).
+//   - Verify the following items.
+//     - DUT remains reachable for N seconds by checking DUT current time is updated.
+//     - DUT boot time is updated after reboot.
+//     - DUT software version is the same after the reboot.
+//  2) Send gNOI reboot request using the method COLD without delay.
+//     - method: Only the COLD method is required to be supported by all targets.
+//     - Delay: 0 - no delay.
+//     - message: Informational reason for the reboot.
+//     - force: Force reboot if basic checks fail. (ex. uncommitted configuration).
+//   - Verify the following items.
+//     - DUT boot time is updated after reboot.
+//     - DUT software version is the same after the reboot.
+//
+// Topology:
+//   dut:port1 <--> ate:port1
+//
+// Test notes:
+//  - A RebootRequest requests the specified target be rebooted using the specified
+//    method after the specified delay.  Only the DEFAULT method with a delay of 0
+//    is guaranteed to be accepted for all target types.
+//  - A RebootMethod determines what should be done with a target when a Reboot is
+//    requested.  Only the COLD method is required to be supported by all
+//    targets.  Methods the target does not support should result in failure.
+//
+//  - gnoi operation commands can be sent and tested using CLI command grpcurl.
+//    https://github.com/fullstorydev/grpcurl
+//
+
+func TestChassisReboot(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+
+	cases := []struct {
+		desc          string
+		rebootRequest *spb.RebootRequest
+	}{
+		{
+			desc: "with delay",
+			rebootRequest: &spb.RebootRequest{
+				Method:  spb.RebootMethod_COLD,
+				Delay:   rebootDelay * oneSecondInNanoSecond,
+				Message: "Reboot chassis with delay",
+				Force:   true,
+			}},
+		{
+			desc: "without delay",
+			rebootRequest: &spb.RebootRequest{
+				Method:  spb.RebootMethod_COLD,
+				Delay:   0,
+				Message: "Reboot chassis without delay",
+				Force:   true,
+			}},
+	}
+
+	versions := gnmi.GetAll(t, dut, gnmi.OC().ComponentAny().SoftwareVersion().State())
+	expectedVersion := FetchUniqueItems(t, versions)
+	sort.Strings(expectedVersion)
+	t.Logf("DUT software version: %v", expectedVersion)
+
+	preRebootCompStatus := gnmi.GetAll(t, dut, gnmi.OC().ComponentAny().OperStatus().State())
+	t.Logf("DUT components status pre reboot: %v", preRebootCompStatus)
+
+	preRebootCompDebug := gnmi.GetAll(t, dut, gnmi.OC().ComponentAny().State())
+	preCompMatrix := []string{}
+	for _, preComp := range preRebootCompDebug {
+		if preComp.GetOperStatus() != oc.PlatformTypes_COMPONENT_OPER_STATUS_UNSET {
+			preCompMatrix = append(preCompMatrix, preComp.GetName()+":"+preComp.GetOperStatus().String())
+		}
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gnoiClient, err := dut.RawAPIs().BindingDUT().DialGNOI(context.Background())
+			if err != nil {
+				t.Fatalf("Error dialing gNOI: %v", err)
+			}
+			bootTimeBeforeReboot := gnmi.Get(t, dut, gnmi.OC().System().BootTime().State())
+			t.Logf("DUT boot time before reboot: %v", bootTimeBeforeReboot)
+			prevTime, err := time.Parse(time.RFC3339, gnmi.Get(t, dut, gnmi.OC().System().CurrentDatetime().State()))
+			if err != nil {
+				t.Fatalf("Failed parsing current-datetime: %s", err)
+			}
+			start := time.Now()
+
+			t.Logf("Send reboot request: %v", tc.rebootRequest)
+			rebootResponse, err := gnoiClient.System().Reboot(context.Background(), tc.rebootRequest)
+			defer gnoiClient.System().CancelReboot(context.Background(), &spb.CancelRebootRequest{})
+			t.Logf("Got reboot response: %v, err: %v", rebootResponse, err)
+			if err != nil {
+				t.Fatalf("Failed to reboot chassis with unexpected err: %v", err)
+			}
+
+			if tc.rebootRequest.GetDelay() > 1 {
+				t.Logf("Validating DUT remains reachable for at least %d seconds", rebootDelay)
+				for {
+					time.Sleep(10 * time.Second)
+					t.Logf("Time elapsed %.2f seconds since reboot was requested.", time.Since(start).Seconds())
+					if time.Since(start).Seconds() > rebootDelay {
+						t.Logf("Time elapsed %.2f seconds > %d reboot delay", time.Since(start).Seconds(), rebootDelay)
+						break
+					}
+					latestTime, err := time.Parse(time.RFC3339, gnmi.Get(t, dut, gnmi.OC().System().CurrentDatetime().State()))
+					if err != nil {
+						t.Fatalf("Failed parsing current-datetime: %s", err)
+					}
+					if latestTime.Before(prevTime) || latestTime.Equal(prevTime) {
+						t.Errorf("Get latest system time: got %v, want newer time than %v", latestTime, prevTime)
+					}
+					prevTime = latestTime
+				}
+			}
+
+			startReboot := time.Now()
+			t.Logf("Wait for DUT to boot up by polling the telemetry output.")
+			for {
+				var currentTime string
+				t.Logf("Time elapsed %.2f seconds since reboot started.", time.Since(startReboot).Seconds())
+				time.Sleep(30 * time.Second)
+				if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
+					currentTime = gnmi.Get(t, dut, gnmi.OC().System().CurrentDatetime().State())
+				}); errMsg != nil {
+					t.Logf("Got testt.CaptureFatal errMsg: %s, keep polling ...", *errMsg)
+				} else {
+					t.Logf("Device rebooted successfully with received time: %v", currentTime)
+					break
+				}
+
+				if uint64(time.Since(startReboot).Seconds()) > maxRebootTime {
+					t.Errorf("Check boot time: got %v, want < %v", time.Since(startReboot), maxRebootTime)
+				}
+			}
+			t.Logf("Device boot time: %.2f seconds", time.Since(startReboot).Seconds())
+
+			bootTimeAfterReboot := gnmi.Get(t, dut, gnmi.OC().System().BootTime().State())
+			t.Logf("DUT boot time after reboot: %v", bootTimeAfterReboot)
+			if bootTimeAfterReboot <= bootTimeBeforeReboot {
+				t.Errorf("Get boot time: got %v, want > %v", bootTimeAfterReboot, bootTimeBeforeReboot)
+			}
+
+			startComp := time.Now()
+			t.Logf("Wait for all the components on DUT to come up")
+
+			for {
+				postRebootCompStatus := gnmi.GetAll(t, dut, gnmi.OC().ComponentAny().OperStatus().State())
+				postRebootCompDebug := gnmi.GetAll(t, dut, gnmi.OC().ComponentAny().State())
+				postCompMatrix := []string{}
+				for _, postComp := range postRebootCompDebug {
+					if postComp.GetOperStatus() != oc.PlatformTypes_COMPONENT_OPER_STATUS_UNSET {
+						postCompMatrix = append(postCompMatrix, postComp.GetName()+":"+postComp.GetOperStatus().String())
+					}
+				}
+
+				if len(preRebootCompStatus) == len(postRebootCompStatus) {
+					t.Logf("All components on the DUT are in responsive state")
+					time.Sleep(10 * time.Second)
+					break
+				}
+
+				if uint64(time.Since(startComp).Seconds()) > maxCompWaitTime {
+					t.Logf("DUT components status post reboot: %v", postRebootCompStatus)
+					if rebootDiff := cmp.Diff(preCompMatrix, postCompMatrix); rebootDiff != "" {
+						t.Logf("[DEBUG] Unexpected diff after reboot (-component missing from pre reboot, +component added from pre reboot): %v ", rebootDiff)
+					}
+					t.Fatalf("There's a difference in components obtained in pre reboot: %v and post reboot: %v.", len(preRebootCompStatus), len(postRebootCompStatus))
+				}
+				time.Sleep(10 * time.Second)
+			}
+
+			versions = gnmi.GetAll(t, dut, gnmi.OC().ComponentAny().SoftwareVersion().State())
+			swVersion := FetchUniqueItems(t, versions)
+			sort.Strings(swVersion)
+			t.Logf("DUT software version after reboot: %v", swVersion)
+			if diff := cmp.Diff(expectedVersion, swVersion); diff != "" {
+				t.Errorf("Software version differed (-want +got):\n%v", diff)
+			}
+		})
+	}
+}
+
+func FetchUniqueItems(t *testing.T, s []string) []string {
+	itemExisted := make(map[string]bool)
+	var uniqueList []string
+	for _, item := range s {
+		if _, ok := itemExisted[item]; !ok {
+			itemExisted[item] = true
+			uniqueList = append(uniqueList, item)
+		} else {
+			t.Logf("Detected duplicated item: %v", item)
+		}
+	}
+	return uniqueList
+}

--- a/lemming.go
+++ b/lemming.go
@@ -222,6 +222,7 @@ func New(targetName, zapiURL string, opts ...Option) (*Device, error) {
 	recs = append(recs,
 		fakedevice.NewSystemBaseTask(),
 		fakedevice.NewBootTimeTask(),
+		fakedevice.NewCurrentTimeTask(),
 		bgp.NewGoBGPTask(targetName, zapiURL, resolvedOpts.bgpPort),
 	)
 
@@ -271,6 +272,11 @@ func New(targetName, zapiURL string, opts ...Option) (*Device, error) {
 		return nil, fmt.Errorf("cannot create gRPC server for P4RT, %v", err)
 	}
 
+	gnoiServer, err := fgnoi.New(s, cacheClient, targetName)
+	if err != nil {
+		return nil, err
+	}
+
 	d := &Device{
 		gnmignoignsiService: &gRPCService{
 			s:       s,
@@ -289,7 +295,7 @@ func New(targetName, zapiURL string, opts ...Option) (*Device, error) {
 			stopped: make(chan struct{}),
 		},
 		gnmiServer:   gnmiServer,
-		gnoiServer:   fgnoi.New(s),
+		gnoiServer:   gnoiServer,
 		gribiServer:  gribiServer,
 		gnsiServer:   gnsiServer,
 		p4rtServer:   fp4rt.New(P4RTs),

--- a/lemming_test.go
+++ b/lemming_test.go
@@ -178,9 +178,9 @@ func TestFakeGNOI(t *testing.T) {
 	}
 
 	cSystem := spb.NewSystemClient(conn)
-	_, err = cSystem.Reboot(context.Background(), &spb.RebootRequest{})
+	_, err = cSystem.SwitchControlProcessor(context.Background(), &spb.SwitchControlProcessorRequest{})
 	if err == nil {
-		t.Errorf("gnoi.System.Reboot failed to return error")
+		t.Errorf("gnoi.System.SwitchControlProcessor failed to return error")
 	}
 
 	cWaveLengthRouter := wrpb.NewWavelengthRouterClient(conn)


### PR DESCRIPTION
* Populate minimum paths in CHASSIS component type to have `gNOI-3.1: Complete Chassis Reboot` pass.
* For Reboot and CancelReboot, only the delay parameter is supported.
* Re-enabled fakedevice.NewCurrentTimeTask()

The Reboot/CancelReboot behaviour is taken from the comments in https://github.com/openconfig/gnoi/blob/main/system/system.proto. The implementation uses non-straightforward concurrency for cleaning-up concurrency signals, but I didn't see another way to do this for now since the spawned goroutine has a limited lifetime.