### PR TITLE
Make BGP prefix checking less flaky

### DIFF
--- a/integration_tests/onedut_oneotg_tests/bgp_route_propagation/bgp_route_propagation_test.go
+++ b/integration_tests/onedut_oneotg_tests/bgp_route_propagation/bgp_route_propagation_test.go
@@ -277,7 +277,7 @@ func checkOTGBGP4Prefix(t *testing.T, otg *otg.OTG, config gosnappi.Config, expe
 	t.Helper()
 	_, ok := gnmi.WatchAll(t,
 		otg,
-		gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv4PrefixAny().State(),
+		gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv4PrefixAny().WithAddress(expectedOTGBGPPrefix.Address).State(),
 		time.Minute,
 		func(v *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix]) bool {
 			_, present := v.Val()
@@ -302,7 +302,7 @@ func checkOTGBGP6Prefix(t *testing.T, otg *otg.OTG, config gosnappi.Config, expe
 	t.Helper()
 	_, ok := gnmi.WatchAll(t,
 		otg,
-		gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv6PrefixAny().State(),
+		gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv6PrefixAny().WithAddress(expectedOTGBGPPrefix.Address).State(),
 		time.Minute,
 		func(v *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv6Prefix]) bool {
 			_, present := v.Val()

--- a/integration_tests/onedut_oneotg_tests/bgp_route_propagation/bgp_route_propagation_test.go
+++ b/integration_tests/onedut_oneotg_tests/bgp_route_propagation/bgp_route_propagation_test.go
@@ -278,7 +278,7 @@ func checkOTGBGP4Prefix(t *testing.T, otg *otg.OTG, config gosnappi.Config, expe
 	_, ok := gnmi.WatchAll(t,
 		otg,
 		gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv4PrefixAny().WithAddress(expectedOTGBGPPrefix.Address).State(),
-		time.Minute,
+		3*time.Minute,
 		func(v *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix]) bool {
 			_, present := v.Val()
 			return present
@@ -303,7 +303,7 @@ func checkOTGBGP6Prefix(t *testing.T, otg *otg.OTG, config gosnappi.Config, expe
 	_, ok := gnmi.WatchAll(t,
 		otg,
 		gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv6PrefixAny().WithAddress(expectedOTGBGPPrefix.Address).State(),
-		time.Minute,
+		3*time.Minute,
 		func(v *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv6Prefix]) bool {
 			_, present := v.Val()
 			return present

--- a/integration_tests/onedut_oneotg_tests/bgp_route_propagation/bgp_route_propagation_test.go
+++ b/integration_tests/onedut_oneotg_tests/bgp_route_propagation/bgp_route_propagation_test.go
@@ -278,7 +278,7 @@ func checkOTGBGP4Prefix(t *testing.T, otg *otg.OTG, config gosnappi.Config, expe
 	_, ok := gnmi.WatchAll(t,
 		otg,
 		gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv4PrefixAny().WithAddress(expectedOTGBGPPrefix.Address).State(),
-		3*time.Minute,
+		time.Minute,
 		func(v *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix]) bool {
 			_, present := v.Val()
 			return present
@@ -303,7 +303,7 @@ func checkOTGBGP6Prefix(t *testing.T, otg *otg.OTG, config gosnappi.Config, expe
 	_, ok := gnmi.WatchAll(t,
 		otg,
 		gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv6PrefixAny().WithAddress(expectedOTGBGPPrefix.Address).State(),
-		3*time.Minute,
+		time.Minute,
 		func(v *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv6Prefix]) bool {
 			_, present := v.Val()
 			return present


### PR DESCRIPTION
Currently it's failing because the `Await` check before the `Get` wait for **any** prefix rather than the prefix `Get` is looking for. This makes some of the checks fail intermittently when multiple prefixes are checked at the same time.