### PR TITLE
Add support for plumbing gRIBI server options through lemming.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -29,7 +29,7 @@ go_library(
         "//p4rt",
         "//sysrib",
         "@com_github_golang_glog//:glog",
-	"@com_github_openconfig_gribigo//server",
+        "@com_github_openconfig_gribigo//server",
         "@io_k8s_klog_v2//:klog",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials",

--- a/BUILD
+++ b/BUILD
@@ -29,7 +29,7 @@ go_library(
         "//p4rt",
         "//sysrib",
         "@com_github_golang_glog//:glog",
-	"@com_github_openconfig_gribigo//server"
+	"@com_github_openconfig_gribigo//server",
         "@io_k8s_klog_v2//:klog",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials",

--- a/BUILD
+++ b/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//p4rt",
         "//sysrib",
         "@com_github_golang_glog//:glog",
+	"@com_github_openconfig_gribigo//server"
         "@io_k8s_klog_v2//:klog",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials",

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/openconfig/gnsi v1.4.5
 	github.com/openconfig/goyang v1.4.5
 	github.com/openconfig/gribi v1.0.0
-	github.com/openconfig/gribigo v0.0.0-20240314002941-b59d04db23bd
+	github.com/openconfig/gribigo v0.0.0-20240712014900-6e0dad60c17a
 	github.com/openconfig/kne v0.1.18
 	github.com/openconfig/magna v0.0.0-20240326180454-518e16696c84
 	github.com/openconfig/ondatra v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -1781,6 +1781,8 @@ github.com/openconfig/gribi v1.0.0 h1:xMwEg0mBD+21mOxuFOw0d9dBKuIPwJEhMUUeUulZdL
 github.com/openconfig/gribi v1.0.0/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
 github.com/openconfig/gribigo v0.0.0-20240314002941-b59d04db23bd h1:MwzM4PieAaHBYDTUd5wMFqzVTzerf3OvHdLmjv7mD+g=
 github.com/openconfig/gribigo v0.0.0-20240314002941-b59d04db23bd/go.mod h1:oMzEmz+ba6QQGNSPMwxJhZxx6gF5GBFnuuQPv6rd0oU=
+github.com/openconfig/gribigo v0.0.0-20240712014900-6e0dad60c17a h1:KTuSH6nuZUQxarrctK/Lw5EzjALKpBYX+U0wqum1/S4=
+github.com/openconfig/gribigo v0.0.0-20240712014900-6e0dad60c17a/go.mod h1:wMFhIe5tmza/FLGS5XtY3JCZfF7U81yyLCWbm8cTETM=
 github.com/openconfig/grpctunnel v0.0.0-20220819142823-6f5422b8ca70 h1:t6SvvdfWCMlw0XPlsdxO8EgO+q/fXnTevDjdYREKFwU=
 github.com/openconfig/grpctunnel v0.0.0-20220819142823-6f5422b8ca70/go.mod h1:OmTWe7RyZj2CIzIgy4ovEBzCLBJzRvWSZmn7u02U9gU=
 github.com/openconfig/kne v0.1.18 h1:8D9SexWhj6knxfvEficyVj0F13GIvF1pQz7TKwVDSUI=

--- a/go.sum
+++ b/go.sum
@@ -1779,8 +1779,6 @@ github.com/openconfig/goyang v1.4.5/go.mod h1:sdNZi/wdTZyLNBNfgLzmmbi7kISm7FskMD
 github.com/openconfig/gribi v0.1.1-0.20210423184541-ce37eb4ba92f/go.mod h1:OoH46A2kV42cIXGyviYmAlGmn6cHjGduyC2+I9d/iVs=
 github.com/openconfig/gribi v1.0.0 h1:xMwEg0mBD+21mOxuFOw0d9dBKuIPwJEhMUUeUulZdLg=
 github.com/openconfig/gribi v1.0.0/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
-github.com/openconfig/gribigo v0.0.0-20240314002941-b59d04db23bd h1:MwzM4PieAaHBYDTUd5wMFqzVTzerf3OvHdLmjv7mD+g=
-github.com/openconfig/gribigo v0.0.0-20240314002941-b59d04db23bd/go.mod h1:oMzEmz+ba6QQGNSPMwxJhZxx6gF5GBFnuuQPv6rd0oU=
 github.com/openconfig/gribigo v0.0.0-20240712014900-6e0dad60c17a h1:KTuSH6nuZUQxarrctK/Lw5EzjALKpBYX+U0wqum1/S4=
 github.com/openconfig/gribigo v0.0.0-20240712014900-6e0dad60c17a/go.mod h1:wMFhIe5tmza/FLGS5XtY3JCZfF7U81yyLCWbm8cTETM=
 github.com/openconfig/grpctunnel v0.0.0-20220819142823-6f5422b8ca70 h1:t6SvvdfWCMlw0XPlsdxO8EgO+q/fXnTevDjdYREKFwU=

--- a/gribi/gribi.go
+++ b/gribi/gribi.go
@@ -162,7 +162,7 @@ func createGRIBIServer(gClient gpb.GNMIClient, target string, root *oc.Root, sys
 		server.WithPostChangeRIBHook(ribHookfn),
 		server.WithRIBResolvedEntryHook(ribAddfn),
 		server.WithVRFs(networkInstances),
-	}, opts...))
+	}, opts...)...)
 }
 
 // createSetRouteRequest converts a Route to a sysrib SetRouteRequest

--- a/gribi/gribi.go
+++ b/gribi/gribi.go
@@ -53,8 +53,10 @@ type Server struct {
 // installed.
 // - root, if specified, will be used to populate connected routes into the RIB
 // manager. Note this is intended to be used for unit/standalone device testing.
-func New(s *grpc.Server, gClient gpb.GNMIClient, target string, root *oc.Root, sysribAddr string) (*Server, error) {
-	gs, err := createGRIBIServer(gClient, target, root, sysribAddr)
+//   - opts, if specified, will be used to control the underlying gRIBI server's
+//     behaviours.
+func New(s *grpc.Server, gClient gpb.GNMIClient, target string, root *oc.Root, sysribAddr string, opts ...server.ServerOpt) (*Server, error) {
+	gs, err := createGRIBIServer(gClient, target, root, sysribAddr, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create gRIBI server, %v", err)
 	}
@@ -73,7 +75,10 @@ func New(s *grpc.Server, gClient gpb.GNMIClient, target string, root *oc.Root, s
 //
 // - root, if specified, will be used to populate connected routes into the RIB
 // manager. Note this is intended to be used for unit/standalone device testing.
-func createGRIBIServer(gClient gpb.GNMIClient, target string, root *oc.Root, sysribAddr string) (*server.Server, error) {
+//
+// The ServerOpt slice provided is handed to the gRIBI fake server to control its
+// behaviour.
+func createGRIBIServer(gClient gpb.GNMIClient, target string, root *oc.Root, sysribAddr string, opts ...server.ServerOpt) (*server.Server, error) {
 	gzebraConn, err := grpc.Dial(sysribAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, fmt.Errorf("cannot dial to sysrib, %v", err)
@@ -153,11 +158,11 @@ func createGRIBIServer(gClient gpb.GNMIClient, target string, root *oc.Root, sys
 		log.Infof("Sent route %v with response %v", routeReq, resp)
 	}
 
-	return server.New(
+	return server.New(append([]server.ServerOpt{
 		server.WithPostChangeRIBHook(ribHookfn),
 		server.WithRIBResolvedEntryHook(ribAddfn),
 		server.WithVRFs(networkInstances),
-	)
+	}, opts...))
 }
 
 // createSetRouteRequest converts a Route to a sysrib SetRouteRequest

--- a/lemming.go
+++ b/lemming.go
@@ -267,7 +267,7 @@ func New(targetName, zapiURL string, opts ...Option) (*Device, error) {
 	if resolvedOpts.disableRIBForwardReferences {
 		gribiOpts = append(gribiOpts, gribis.WithNoRIBForwardReferences())
 	}
-	gribiServer, err := fgribi.New(s, cacheClient, targetName, root,fmt.Sprintf("unix:%s", resolvedOpts.sysribAddr), gribiOpts...)
+	gribiServer, err := fgribi.New(s, cacheClient, targetName, root, fmt.Sprintf("unix:%s", resolvedOpts.sysribAddr), gribiOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/lemming.go
+++ b/lemming.go
@@ -267,7 +267,7 @@ func New(targetName, zapiURL string, opts ...Option) (*Device, error) {
 	if resolvedOpts.disableRIBForwardReferences {
 		gribiOpts = append(gribiOpts, gribis.WithNoRIBForwardReferences())
 	}
-	gribiServer, err := fgribi.New(s, cacheClient, targetName, root,fmt.Sprintf("unix:%s", resolvedOpts.sysribAddr) gribiOpts...)
+	gribiServer, err := fgribi.New(s, cacheClient, targetName, root,fmt.Sprintf("unix:%s", resolvedOpts.sysribAddr), gribiOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1437,8 +1437,8 @@ def go_repositories():
     go_repository(
         name = "com_github_openconfig_gribigo",
         importpath = "github.com/openconfig/gribigo",
-        sum = "h1:MwzM4PieAaHBYDTUd5wMFqzVTzerf3OvHdLmjv7mD+g=",
-        version = "v0.0.0-20240314002941-b59d04db23bd",
+        sum = "h1:KTuSH6nuZUQxarrctK/Lw5EzjALKpBYX+U0wqum1/S4=",
+        version = "v0.0.0-20240712014900-6e0dad60c17a",
     )
     go_repository(
         name = "com_github_openconfig_grpctunnel",
@@ -1881,12 +1881,6 @@ def go_repositories():
         importpath = "github.com/vishvananda/netns",
         sum = "h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=",
         version = "v0.0.4",
-    )
-    go_repository(
-        name = "com_github_wenovus_gobgp_v3",
-        importpath = "github.com/wenovus/gobgp/v3",
-        sum = "h1:jse5eORjbrlTIOPzOO3cpm4feJ16ZCntxzAHSdcWuy4=",
-        version = "v3.0.0-20230831013712-6d33842cbf42",
     )
     go_repository(
         name = "com_github_wi2l_jsondiff",
@@ -3078,8 +3072,8 @@ def go_repositories():
         name = "org_golang_google_grpc",
         build_file_proto_mode = "disable",
         importpath = "google.golang.org/grpc",
-        sum = "h1:KH3VH9y/MgNQg1dE7b3XfVK0GsPSIzJwdF617gUSbvY=",
-        version = "v1.64.0",
+        sum = "h1:LKtvyfbX3UGVPFcGqJ9ItpVWW6oN/2XqTxfAnwRRXiA=",
+        version = "v1.64.1",
     )
     go_repository(
         name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",


### PR DESCRIPTION
```
 * (M) lemming.go
 * (M) gribi/gribi.go
  - for some behaviours, there is a need to change the underlying RIB functionality
    in the gRIBI server as a lemming is created. this change plumbs some options
    through to allow lemmings to be created using this method.
```
