### PR TITLE
Address infinite loop when recursively resolving routes.

### DIFF
--- a/sysrib/server.go
+++ b/sysrib/server.go
@@ -586,8 +586,6 @@ func (s *Server) SetRoute(ctx context.Context, req *sysribpb.SetRouteRequest) (*
 		})
 	}
 
-	// TODO(wenbli): Check if recursive resolution is an infinite recursion. This happens if there is a cycle.
-
 	niName := vrfIDToNiName(req.GetVrfId())
 	if err := s.setRoute(ctx, niName, &Route{
 		Prefix:   pfx,


### PR DESCRIPTION
```
* (M) sysrib/{server,server_test,sysrib,sysrib_test}.go
   - Avoid infinite stack depth when a route recurses onto itself.
     Previously, looking up a next-hop or next-hop interface would
     not track the visited nodes, and hence infinite recursion could
     occur. This PR adds tracking of these changes into the RIB
     lookup to avoid this.
```
