### PR TITLE
Update gRIBI server to accommodate gRPC changes.

### DIFF
--- a/gribi/gribi.go
+++ b/gribi/gribi.go
@@ -62,9 +62,8 @@ func New(s *grpc.Server, gClient gpb.GNMIClient, target string, root *oc.Root, s
 	}
 
 	srv := &Server{
-		UnimplementedGRIBIServer: &gribipb.UnimplementedGRIBIServer{},
-		Server:                   gs,
-		s:                        s,
+		Server: gs,
+		s:      s,
 	}
 	gribipb.RegisterGRIBIServer(s, srv)
 
@@ -159,11 +158,16 @@ func createGRIBIServer(gClient gpb.GNMIClient, target string, root *oc.Root, sys
 		log.Infof("Sent route %v with response %v", routeReq, resp)
 	}
 
-	return server.New(append([]server.ServerOpt{
+	s, err := server.New(append([]server.ServerOpt{
 		server.WithPostChangeRIBHook(ribHookfn),
 		server.WithRIBResolvedEntryHook(ribAddfn),
 		server.WithVRFs(networkInstances),
 	}, opts...)...)
+	if err != nil {
+		return nil, err
+	}
+	s.UnimplementedGRIBIServer = &gribipb.UnimplementedGRIBIServer{}
+	return s, nil
 }
 
 // createSetRouteRequest converts a Route to a sysrib SetRouteRequest

--- a/gribi/gribi.go
+++ b/gribi/gribi.go
@@ -62,8 +62,9 @@ func New(s *grpc.Server, gClient gpb.GNMIClient, target string, root *oc.Root, s
 	}
 
 	srv := &Server{
-		Server: gs,
-		s:      s,
+		UnimplementedGRIBIServer: &gribipb.UnimplementedGRIBIServer{},
+		Server:                   gs,
+		s:                        s,
 	}
 	gribipb.RegisterGRIBIServer(s, srv)
 


### PR DESCRIPTION
```
commit ebfc91c7200f6e3a41e3c4a73eadd115520383e2
Author: Rob Shakir <robjs@google.com>
Date:   Mon Jan 6 20:34:01 2025 +0000

    Initialise the unimplemented server given that gRIBI is embedded.
    
     * (M) gribi/gribi.go
       - Ensure that the unimplemented server is initialised correctly.
```

This is required since gRPC added a check that the unimplemented servers
that are embedded as pointers must not be nil.
