### PR TITLE
Make Lucius Robust to handle invalid packets like ICMPv6 over IPV4

### DIFF
--- a/dataplane/forwarding/protocol/icmp/icmp6.go
+++ b/dataplane/forwarding/protocol/icmp/icmp6.go
@@ -170,27 +170,31 @@ func (i *ICMP6) Rebuild() error {
 		return nil
 	}
 
+	var err error
+	var fSrc, fDst []byte
+	if fSrc, err = i.desc.Packet.Field(fwdpacket.NewFieldIDFromNum(fwdpb.PacketFieldNum_PACKET_FIELD_NUM_IP_ADDR_SRC, fwdpacket.LastField)); err != nil {
+		return fmt.Errorf("icmp6: Rebuild failed: %v", err)
+	}
+	if fDst, err = i.desc.Packet.Field(fwdpacket.NewFieldIDFromNum(fwdpb.PacketFieldNum_PACKET_FIELD_NUM_IP_ADDR_DST, fwdpacket.LastField)); err != nil {
+		return fmt.Errorf("icmp6: Rebuild failed: %v", err)
+	}
+
+	if len(fSrc) != protocol.SizeIP6 || len(fDst) != protocol.SizeIP6 {
+		return fmt.Errorf("icmp6: Rebuild failed, invalid IP address length (src=%v, dst=%v)", len(fSrc), len(fDst))
+	}
+
 	i.header.Field(csumOffset, csumBytes).SetValue(0)
 	var sum csum16.Sum
-
-	var err error
-	var f []byte
-	if f, err = i.desc.Packet.Field(fwdpacket.NewFieldIDFromNum(fwdpb.PacketFieldNum_PACKET_FIELD_NUM_IP_ADDR_SRC, fwdpacket.LastField)); err != nil {
-		return fmt.Errorf("icmp6: Rebuild failed: %v", err)
-	}
-	sum.Write(f)
-	if f, err = i.desc.Packet.Field(fwdpacket.NewFieldIDFromNum(fwdpb.PacketFieldNum_PACKET_FIELD_NUM_IP_ADDR_DST, fwdpacket.LastField)); err != nil {
-		return fmt.Errorf("icmp6: Rebuild failed: %v", err)
-	}
-	sum.Write(f)
+	_, _ = sum.Write(fSrc)
+	_, _ = sum.Write(fDst)
 
 	length := len(i.header)
-	f = make([]byte, protocol.SizeUint32)
+	f := make([]byte, protocol.SizeUint32)
 	binary.BigEndian.PutUint32(f, uint32(length))
-	sum.Write(f)
+	_, _ = sum.Write(f)
 
-	sum.Write([]byte{0, 0, 0, protoICMP6})
-	sum.Write(i.header)
+	_, _ = sum.Write([]byte{0, 0, 0, protoICMP6})
+	_, _ = sum.Write(i.header)
 	i.header.Field(csumOffset, csumBytes).SetValue(uint(sum))
 	return nil
 }


### PR DESCRIPTION
A robustness check is added to ICMP6.Rebuild() in the Lucius forwarding dataplane to handle invalid packets like ICMPv6 over IPV4.
The ICMPv6 checksum gets calculated from "IPv6 pseudo-header" which explicitly requires 16-byte IPv6 Source and Destination addresses.  In this case the provided addresses were only 4 bytes long.
Added a strict validation step to ensure both IP addresses are exactly 16 bytes (protocol.SizeIP6). If they are not (as is the case with an invalid ICMPv6-over-IPv4 packet), the Rebuild() function aborts early and safely skips the checksum rewrite. This prevents the bogus checksum calculation and guarantees that opaque test payloads remain completely unmodified.