### PR TITLE
Add support for handling hop-by-hop packets in Lucius

### DIFF
--- a/dataplane/forwarding/fwdconfig/table.go
+++ b/dataplane/forwarding/fwdconfig/table.go
@@ -203,7 +203,8 @@ func (b ActionEntryBuilder) set(ed *fwdpb.EntryDesc) {
 
 // FlowEntryBuilder builds flow table entries.
 type FlowEntryBuilder struct {
-	fields []*PacketFieldMaskedBytesBuilder
+	fields   []*PacketFieldMaskedBytesBuilder
+	priority uint32
 }
 
 // FlowEntry creates a new flow entry builder.
@@ -213,8 +214,16 @@ func FlowEntry(fields ...*PacketFieldMaskedBytesBuilder) *FlowEntryBuilder {
 	}
 }
 
+// WithPriority sets the priority of the flow entry.
+func (eeb *FlowEntryBuilder) WithPriority(priority uint32) *FlowEntryBuilder {
+	eeb.priority = priority
+	return eeb
+}
+
 func (eeb FlowEntryBuilder) set(ed *fwdpb.EntryDesc) {
-	flow := &fwdpb.FlowEntryDesc{}
+	flow := &fwdpb.FlowEntryDesc{
+		Priority: eeb.priority,
+	}
 	for _, b := range eeb.fields {
 		flow.Fields = append(flow.Fields, b.Build())
 	}

--- a/dataplane/saiserver/hostif_test.go
+++ b/dataplane/saiserver/hostif_test.go
@@ -349,10 +349,11 @@ func createPacket(t testing.TB, nid uint64) fwdpacket.Packet {
 		EthernetType: layers.EthernetTypeIPv6,
 	}
 	ip := &layers.IPv6{
-		Version:  6,
-		SrcIP:    net.ParseIP("2003::9"),
-		DstIP:    net.ParseIP("2003::10"),
-		HopLimit: 255,
+		Version:    6,
+		SrcIP:      net.ParseIP("2003::9"),
+		DstIP:      net.ParseIP("2003::10"),
+		HopLimit:   255,
+		NextHeader: layers.IPProtocolUDP,
 	}
 	payload := gopacket.Payload([]byte("hello world"))
 	buf := gopacket.NewSerializeBuffer()

--- a/dataplane/saiserver/switch.go
+++ b/dataplane/saiserver/switch.go
@@ -992,12 +992,42 @@ func (sw *saiSwitch) createInvalidPacketFilter(ctx context.Context) error {
 				}
 				req := fwdconfig.TableEntryAddRequest(sw.dataplane.ID(), table).
 					AppendEntry(
-						fwdconfig.EntryDesc(fwdconfig.FlowEntry(fwdconfig.PacketFieldMaskedBytes(field).WithBytes(prefix.IP, prefix.Mask))),
+						fwdconfig.EntryDesc(fwdconfig.FlowEntry(fwdconfig.PacketFieldMaskedBytes(field).WithBytes(prefix.IP, prefix.Mask)).WithPriority(20)),
 						fwdconfig.UpdateAction(fwdpb.UpdateType_UPDATE_TYPE_BIT_WRITE, fwdpb.PacketFieldNum_PACKET_FIELD_NUM_PACKET_ACTION).WithBitOp(1, 0).WithValue([]byte{0}),
 					).Build()
 				if _, err := sw.dataplane.TableEntryAdd(ctx, req); err != nil {
 					return err
 				}
+			}
+		}
+
+		if table == invalidIngressV6Table {
+			// Drop Hop-by-Hop options with unicast destination if not already trapped (PACKET_ACTION == 1).
+			// Rule 1: Multicast (dst starts with 0xFF) -> Continue
+			reqHopByHopMC := fwdconfig.TableEntryAddRequest(sw.dataplane.ID(), table).
+				AppendEntry(
+					fwdconfig.EntryDesc(fwdconfig.FlowEntry(
+						fwdconfig.PacketFieldMaskedBytes(fwdpb.PacketFieldNum_PACKET_FIELD_NUM_IP_PROTO).WithBytes([]byte{0}, []byte{0xFF}),
+						fwdconfig.PacketFieldMaskedBytes(fwdpb.PacketFieldNum_PACKET_FIELD_NUM_IP_ADDR_DST).WithBytes([]byte{0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, []byte{0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+						fwdconfig.PacketFieldMaskedBytes(fwdpb.PacketFieldNum_PACKET_FIELD_NUM_PACKET_ACTION).WithBytes([]byte{1}, []byte{0xFF}),
+					).WithPriority(10)),
+					fwdconfig.ContinueAction(),
+				).Build()
+			if _, err := sw.dataplane.TableEntryAdd(ctx, reqHopByHopMC); err != nil {
+				return err
+			}
+
+			// Rule 2: Unicast (any other dst) -> Drop
+			reqHopByHopUC := fwdconfig.TableEntryAddRequest(sw.dataplane.ID(), table).
+				AppendEntry(
+					fwdconfig.EntryDesc(fwdconfig.FlowEntry(
+						fwdconfig.PacketFieldMaskedBytes(fwdpb.PacketFieldNum_PACKET_FIELD_NUM_IP_PROTO).WithBytes([]byte{0}, []byte{0xFF}),
+						fwdconfig.PacketFieldMaskedBytes(fwdpb.PacketFieldNum_PACKET_FIELD_NUM_PACKET_ACTION).WithBytes([]byte{1}, []byte{0xFF}),
+					).WithPriority(5)),
+					fwdconfig.UpdateAction(fwdpb.UpdateType_UPDATE_TYPE_BIT_WRITE, fwdpb.PacketFieldNum_PACKET_FIELD_NUM_PACKET_ACTION).WithBitOp(1, 0).WithValue([]byte{0}),
+				).Build()
+			if _, err := sw.dataplane.TableEntryAdd(ctx, reqHopByHopUC); err != nil {
+				return err
 			}
 		}
 		// Before the TTL is decremented and after the packets may be punted, drop packet with TTL == 1 or TTL == 0.

--- a/integration_tests/dataplane/mplsoudp/mplsoverudp_test.go
+++ b/integration_tests/dataplane/mplsoudp/mplsoverudp_test.go
@@ -206,10 +206,11 @@ func TestMPLSoverUDP(t *testing.T) {
 	}
 
 	ip := &layers.IPv6{
-		Version:  6,
-		SrcIP:    net.ParseIP("2003::9"),
-		DstIP:    net.ParseIP("2003::10"),
-		HopLimit: 255,
+		Version:    6,
+		NextHeader: layers.IPProtocolNoNextHeader,
+		SrcIP:      net.ParseIP("2003::9"),
+		DstIP:      net.ParseIP("2003::10"),
+		HopLimit:   255,
 	}
 	payload := gopacket.Payload([]byte("hello world"))
 
@@ -251,10 +252,11 @@ func TestMPLSoverUDP(t *testing.T) {
 		Label: 100,
 	}
 	wantInnerIP := &layers.IPv6{
-		Version:  6,
-		SrcIP:    net.ParseIP("2003::9"),
-		DstIP:    net.ParseIP("2003::10"),
-		HopLimit: 255,
+		Version:    6,
+		NextHeader: layers.IPProtocolNoNextHeader,
+		SrcIP:      net.ParseIP("2003::9"),
+		DstIP:      net.ParseIP("2003::10"),
+		HopLimit:   255,
 	}
 	buf = gopacket.NewSerializeBuffer()
 	if err := gopacket.SerializeLayers(buf, gopacket.SerializeOptions{FixLengths: true}, wantMPLS, wantInnerIP, payload); err != nil {


### PR DESCRIPTION
This diff ensures that Hop-by-Hop packets are no longer prematurely dropped as malformed by the parser. Instead, it allows them into the pipeline where it installs explicit rules to drop unicast Hop-by-Hop packets while permitting multicast Hop-by-Hop packets to continue.
table.go: A WithPriority(priority uint32) method was added to the FlowEntryBuilder. The dataplane uses flow tables to match packets against rules. Because the new Hop-by-Hop rules need to distinguish between multicast and unicast packets, the rules need explicit priorities to ensure the switch evaluates them in the correct order.
switch.go: In the createInvalidPacketFilter function, it uses the new WithPriority API to install specific Hop-by-Hop filtering rules into the IPv6 invalid ingress table (invalidIngressV6Table). It applies 3 rules Existing invalid prefix rule (Priority 20), Rule 1 - Multicast Hop-by-Hop (Priority 10), Rule 2 - Unicast Hop-by-Hop (Priority 5). 
