### PR TITLE
operator/api: align scheme builder with standard k8s.io/apimachinery

### DIFF
--- a/operator/api/lemming/v1alpha1/BUILD
+++ b/operator/api/lemming/v1alpha1/BUILD
@@ -14,6 +14,5 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_apimachinery//pkg/runtime/schema",
-        "@io_k8s_sigs_controller_runtime//pkg/scheme",
     ],
 )

--- a/operator/api/lemming/v1alpha1/groupversion_info.go
+++ b/operator/api/lemming/v1alpha1/groupversion_info.go
@@ -18,8 +18,8 @@
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -30,7 +30,7 @@ var (
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/operator/api/lemming/v1alpha1/lemming_types.go
+++ b/operator/api/lemming/v1alpha1/lemming_types.go
@@ -17,6 +17,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -123,6 +124,11 @@ type LemmingList struct {
 	Items           []Lemming `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&Lemming{}, &LemmingList{})
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&Lemming{},
+		&LemmingList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
 }


### PR DESCRIPTION
Refactor operator/api/lemming/v1alpha1 to use standard runtime.NewSchemeBuilder from k8s.io/apimachinery instead of sigs.k8s.io/controller-runtime's scheme.Builder.

Summary of changes:
- operator/api/lemming/v1alpha1/groupversion_info.go:
  - Initialize SchemeBuilder using runtime.NewSchemeBuilder(addKnownTypes) instead of &scheme.Builder{GroupVersion: GroupVersion}.
- operator/api/lemming/v1alpha1/lemming_types.go:
  - Implement addKnownTypes() to register Lemming and LemmingList types and group-version metadata directly with the runtime scheme.
  - Remove init() block that previously called SchemeBuilder.Register().

Rationale:
- Removes reliance on controller-runtime internal scheme builders for API type definitions.
- Aligns API registration with standard k8s.io/apimachinery conventions used across client-gen and Kubernetes CRD tooling.
- Eliminates package initialization side-effects and prevents type conversion mismatches in downstream integrations.

Note for googlers - see b/540005636 and cl/968544355