### PR TITLE
Don't allocate nodeports for lemming k8s services

### DIFF
--- a/operator/controllers/lemming_controller.go
+++ b/operator/controllers/lemming_controller.go
@@ -303,7 +303,8 @@ func (r *LemmingReconciler) reconcileService(ctx context.Context, lemming *lemmi
 			},
 		}
 		service.Spec = corev1.ServiceSpec{
-			Type: corev1.ServiceTypeLoadBalancer,
+			Type:                          corev1.ServiceTypeLoadBalancer,
+			AllocateLoadBalancerNodePorts: pointer.Bool(false),
 			Selector: map[string]string{
 				"app":  lemming.Name,
 				"topo": lemming.Namespace,

--- a/operator/controllers/lemming_controller_test.go
+++ b/operator/controllers/lemming_controller_test.go
@@ -97,7 +97,8 @@ func TestReconcile(t *testing.T) {
 					"app":  "lemming",
 					"topo": "fake",
 				},
-				Type: corev1.ServiceTypeLoadBalancer,
+				Type:                          corev1.ServiceTypeLoadBalancer,
+				AllocateLoadBalancerNodePorts: pointer.Bool(false),
 				Ports: []corev1.ServicePort{{
 					Name:       "gnmi",
 					Protocol:   corev1.ProtocolTCP,


### PR DESCRIPTION
Lemming is light and a natural choice for scale testing, but currently allocates nodeports for every service - 2 per lemming node. This consumes nodeports quickly.

This disables nodeports for these services, consistent with what KNE does for other node types.