### PR TITLE
validate ipv4 and ipv6 packets based on version check

### DIFF
--- a/dataplane/forwarding/protocol/ip/ip4.go
+++ b/dataplane/forwarding/protocol/ip/ip4.go
@@ -140,6 +140,9 @@ func (ip *IP4) Payload() (fwdpb.PacketHeaderId, int64) {
 
 // SetPayload sets the payload.
 func (ip *IP4) SetPayload(id fwdpb.PacketHeaderId, length int64) {
+	if ipVersion(ip.header).Value() != 0x4 {
+		return
+	}
 	proto, ok := headerProto[id]
 	if !ok {
 		proto = protoReserved

--- a/dataplane/forwarding/protocol/ip/ip6.go
+++ b/dataplane/forwarding/protocol/ip/ip6.go
@@ -159,6 +159,9 @@ func (ip *IP6) Payload() (fwdpb.PacketHeaderId, int64) {
 
 // SetPayload sets the payload.
 func (ip *IP6) SetPayload(id fwdpb.PacketHeaderId, length int64) {
+	if ipVersion(ip.header).Value() != 0x6 {
+		return
+	}
 	proto, ok := headerProto[id]
 	if !ok {
 		proto = protoReserved


### PR DESCRIPTION
When a packet is parsed as IPv4 or IPv6 based on its Ethertype, but contains an invalid IP Version field (e.g. Version != 4 or Version != 6), Lucius still blindly updates its payload length and checksum during L3 forwarding simulation in SetPayload().
This change adds a version check to ensure that if the IP version is incorrect then drop these packets